### PR TITLE
Ensure JQ starts at container definition key when dereferencing

### DIFF
--- a/examples/hello-world.json
+++ b/examples/hello-world.json
@@ -1,18 +1,14 @@
-{
-    "containerDefinitions": [
-        {
-            "essential": true,
-            "image": "amazon/amazon-ecs-sample",
-            "memory": 100,
-            "name": "sample",
-            "portMappings": [
-                {
-                    "containerPort": 80,
-                    "hostPort": 80
-                }
-            ]
-        }
-    ],
-    "family": "hello-world",
-    "volumes": []
-}
+[
+    {
+        "essential": true,
+        "image": "amazon/amazon-ecs-sample",
+        "memory": 100,
+        "name": "sample",
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 80
+            }
+        ]
+    }
+]

--- a/hooks/command
+++ b/hooks/command
@@ -24,7 +24,7 @@ function create_service() {
 
 ## This is the template definition of your containers
 container_definitions_json=$(jq --arg IMAGE "$image" \
-'.taskDefinition.containerDefinitions[0].image=$IMAGE' \
+'.[0].image=$IMAGE' \
 "$task_definition"
 )
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -15,7 +15,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
 
   stub jq \
-    "--arg IMAGE hello-world:llamas '.taskDefinition.containerDefinitions[0].image=\$IMAGE' examples/hello-world.json : echo '{\"json\":true}'" \
+    "--arg IMAGE hello-world:llamas '.[0].image=\$IMAGE' examples/hello-world.json : echo '{\"json\":true}'" \
     "'.taskDefinition.revision' : echo 1"
 
   stub aws \
@@ -46,7 +46,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
 
   stub jq \
-    "--arg IMAGE hello-world:llamas '.taskDefinition.containerDefinitions[0].image=\$IMAGE' examples/hello-world.json : echo '{\"json\":true}'" \
+    "--arg IMAGE hello-world:llamas '.[0].image=\$IMAGE' examples/hello-world.json : echo '{\"json\":true}'" \
     "'.taskDefinition.revision' : echo 1"
 
   stub aws \
@@ -79,7 +79,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN=arn:aws:iam::012345678910:role/world
 
   stub jq \
-    "--arg IMAGE hello-world:llamas '.taskDefinition.containerDefinitions[0].image=\$IMAGE' examples/hello-world.json : echo '{\"json\":true}'" \
+    "--arg IMAGE hello-world:llamas '.[0].image=\$IMAGE' examples/hello-world.json : echo '{\"json\":true}'" \
     "'.taskDefinition.revision' : echo 1"
 
   stub aws \


### PR DESCRIPTION
As per the example, the task definition just contains a list of Container Definitions.
Therefore we start our dereference at the array of definitions, not the task definitions