### PR TITLE
Add support for multiple images in a single pipeline/definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,16 @@ Example: `"my-task"`
 
 ### `image`
 
-The Docker image to deploy.
+The Docker image to deploy. This can be an array to substitute multiple images in a single container definition.
 
-Example: `"012345.dkr.ecr.us-east-1.amazonaws.com/my-service:123"`
+Examples:
+`"012345.dkr.ecr.us-east-1.amazonaws.com/my-service:123"`
+
+```yaml
+image:
+  - "012345.dkr.ecr.us-east-1.amazonaws.com/my-service:123"
+  - "012345.dkr.ecr.us-east-1.amazonaws.com/nginx:123"
+```
 
 ### `target-group`
 

--- a/examples/multiple-images.json
+++ b/examples/multiple-images.json
@@ -1,0 +1,26 @@
+[
+    {
+        "essential": true,
+        "image": "amazon/amazon-ecs-sample",
+        "memory": 100,
+        "name": "sample",
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 80
+            }
+        ]
+    },
+    {
+        "essential": true,
+        "image": "amazon/amazon-ecs-sample",
+        "memory": 100,
+        "name": "sample",
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 80
+            }
+        ]
+    }
+]

--- a/hooks/command
+++ b/hooks/command
@@ -48,9 +48,11 @@ function create_service() {
     local target_group_arguments
     target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
 
+    # shellcheck disable=SC2016
     service_defined=$(aws ecs describe-services --cluster "$cluster_name" --service "$service_name" --query 'services[?status==`ACTIVE`].status' --output text |wc -l)
     if [[ $service_defined -eq 0 ]]; then
         echo "--- :ecs: Creating a Service $service_name in cluster $cluster_name"
+        # shellcheck disable=SC2086
         aws ecs create-service --cluster "$cluster_name" --service-name "$service_name" --task-definition "$task_definition" --desired-count "$desired_count" $target_group_arguments
     fi
 }
@@ -68,9 +70,9 @@ function generate_target_group_arguments() {
 
 ## This is the template definition of your containers
 image_idx=0
-container_definitions_json=$(cat ${task_definition})
+container_definitions_json=$(cat "${task_definition}")
 for image in "${images[@]}"; do
-  container_definitions_json=$(echo $container_definitions_json | jq --arg IMAGE "$image" \
+  container_definitions_json=$(echo "$container_definitions_json" | jq --arg IMAGE "$image" \
   ".[${image_idx}].image=\$IMAGE"
   )
   image_idx=$((image_idx+1))
@@ -103,6 +105,7 @@ echo "Registered ${task_family}:${task_revision}"
 # Create service if it doesn't already exist
 create_service "$cluster" "${task_family}:${task_revision}" "$service_name" "$desired_count" "$target_group" "$target_container" "$target_port"
 
+# shellcheck disable=SC2016
 lb_config=$(aws ecs describe-services --cluster "$cluster" --services "$service_name" --query 'services[?status==`ACTIVE`]' |jq -r '.[0].loadBalancers[0]')
 error="+++ Cannot update a service to add a load balancer. First delete the service and then run again, or rename the service to force a new one to be created"
 

--- a/hooks/command
+++ b/hooks/command
@@ -1,10 +1,33 @@
 #!/bin/bash
 set -euo pipefail
 
+# Reads either a value or a list from plugin config
+function plugin_read_list() {
+  prefix_read_list "BUILDKITE_PLUGIN_ECS_DEPLOY_$1"
+}
+
+# Reads either a value or a list from the given env prefix
+function prefix_read_list() {
+  local prefix="$1"
+  local parameter="${prefix}_0"
+
+  if [[ -n "${!parameter:-}" ]]; then
+    local i=0
+    local parameter="${prefix}_${i}"
+    while [[ -n "${!parameter:-}" ]]; do
+      echo "${!parameter}"
+      i=$((i+1))
+      parameter="${prefix}_${i}"
+    done
+  elif [[ -n "${!prefix:-}" ]]; then
+    echo "${!prefix}"
+  fi
+}
+
 cluster=${BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER?}
 task_family=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY?}
 service_name=${BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE?}
-image=${BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE?}
+images=($(plugin_read_list IMAGE))
 task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION?}
 desired_count=${BUILDKITE_PLUGIN_ECS_DEPLOY_DESIRED_COUNT:-"1"}
 task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-""}
@@ -41,10 +64,14 @@ function generate_target_group_arguments() {
 }
 
 ## This is the template definition of your containers
-container_definitions_json=$(jq --arg IMAGE "$image" \
-'.[0].image=$IMAGE' \
-"$task_definition"
-)
+image_idx=0
+container_definitions_json=$(cat ${task_definition})
+for image in "${images[@]}"; do
+  container_definitions_json=$(echo $container_definitions_json | jq --arg IMAGE "$image" \
+  ".[${image_idx}].image=\$IMAGE"
+  )
+  image_idx=$((image_idx+1))
+done
 
 echo "jq --arg IMAGE $image \
 '.taskDefinition.containerDefinitions[0].image=\$IMAGE' \

--- a/hooks/command
+++ b/hooks/command
@@ -27,7 +27,10 @@ function prefix_read_list() {
 cluster=${BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER?}
 task_family=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY?}
 service_name=${BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE?}
-images=($(plugin_read_list IMAGE))
+images=()
+while read -r line ; do
+  [[ -n "$line" ]] && images+=("$line")
+done <<< "$(plugin_read_list IMAGE)"
 task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION?}
 desired_count=${BUILDKITE_PLUGIN_ECS_DEPLOY_DESIRED_COUNT:-"1"}
 task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-""}

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,7 +15,7 @@ configuration:
     task-family:
       type: string
     image:
-      type: string
+      type: [ string, array ]
     desired-count:
       type: string
     task-role-arn:


### PR DESCRIPTION
It's common to have multiple images in the same container definition, say a web server and application server.

This allows you to specify an array for `image` argument which replaces each image in the container definition, in the respective order.