### PR TITLE
 Output service events when deploy fails

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -98,12 +98,21 @@ aws ecs update-service \
 
 ## Now we wait till it's stable
 echo "--- :ecs: Waiting for services to stabilize"
+deploy_exitcode=0
 aws ecs wait services-stable \
   --cluster "${cluster}" \
-  --services "${service_name}"
+  --services "${service_name}" || deploy_exitcode=$?
 
-aws ecs describe-services \
+
+services_events=$(aws ecs describe-services \
   --cluster "${cluster}" \
-  --service "${service_name}"
+  --service "${service_name}")
 
-echo "+++ :ecs: Service is up 🚀"
+if [[ $deploy_exitcode -eq 0 ]]; then
+  echo "--- :ecs: Service is up 🚀"
+  echo $service_events
+else
+  echo "+++ :ecs: Service failed to deploy ❌"
+  echo $service_events
+  exit $deploy_exitcode
+fi

--- a/hooks/command
+++ b/hooks/command
@@ -182,9 +182,9 @@ service_events=$(aws ecs describe-services \
 
 if [[ $deploy_exitcode -eq 0 ]]; then
   echo "--- :ecs: Service is up 🚀"
-  echo $service_events
+  echo "$service_events"
 else
   echo "+++ :ecs: Service failed to deploy ❌"
-  echo $service_events
+  echo "$service_events"
   exit $deploy_exitcode
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -104,9 +104,10 @@ aws ecs wait services-stable \
   --services "${service_name}" || deploy_exitcode=$?
 
 
-services_events=$(aws ecs describe-services \
+service_events=$(aws ecs describe-services \
   --cluster "${cluster}" \
-  --service "${service_name}")
+  --service "${service_name}" \
+  --query 'services[].events' --output text)
 
 if [[ $deploy_exitcode -eq 0 ]]; then
   echo "--- :ecs: Service is up 🚀"


### PR DESCRIPTION
The service events are very helpful when debugging why a service deployment failed.
We also improve the formatting of the events.