### PR TITLE
Add option to pass region

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ steps:
     concurrency_group: "my-service-deploy"
     concurrency: 1
     plugins:
-      - ecs-deploy#v1.2.0:
+      - ecs-deploy#v1.3.0:
           cluster: "my-ecs-cluster"
           service: "my-service"
           task-definition: "examples/hello-world.json"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The minimum and maximum percentage of tasks that should be maintained during a d
 
 Example: `"0/100"`
 
-### `region` (option)
+### `region` (optional)
 
 The region we deploy the ECS Service to.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ The minimum and maximum percentage of tasks that should be maintained during a d
 
 Example: `"0/100"`
 
+### `region` (option)
+
+The region we deploy the ECS Service to.
+
 ## AWS Roles
 
 At a minimum this plugin requires the following AWS permissions to be granted to the agent running this step:

--- a/hooks/command
+++ b/hooks/command
@@ -39,6 +39,11 @@ load_balancer_name=${BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME:-""}
 target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
 target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
 execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
+region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
+
+if [[ $region != "" ]]; then
+    AWS_DEFAULT_REGION=${region}
+fi
 
 # Resolve any runtime environment variables it has
 target_group=$(eval "echo $target_group")


### PR DESCRIPTION
This allows the plugin to be used for any region, not just the default set for your Buildkite Agent (if any)