### PR TITLE
Check container definition format

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -147,7 +147,7 @@ error="+++ ^^^
 # No easy way to tell if the target group has changed, since describe-services only returns the load balancer name
 if [[ "$lb_config" == "null" ]]; then
   if [[ -n "$target_group" ]] || [[ -n "$load_balancer_name" ]]; then
-    echo "$error"
+    echo "$error. ELB configured but none set in container"
     exit 1
   fi
 fi
@@ -156,13 +156,13 @@ if [[ "$lb_config" == "null" ]]; then
   # noop
   true
 elif [[ $(echo "$lb_config" |jq -r '.containerName') != "$target_container" ]] || [[ $(echo "$lb_config" |jq -r '.containerPort') -ne $target_port ]]; then
-  echo "$error"
+  echo "$error. Container config differs"
   exit 1
 elif [[ -n "$target_group" ]] && [[ $(echo "$lb_config" |jq -r '.targetGroupArn') != "$target_group" ]]; then
-  echo "$error"
+  echo "$error. ALB config differs"
   exit 1
 elif [[ -n "$load_balancer_name" ]] && [[ $(echo "$lb_config" |jq -r '.loadBalancerName') != "$load_balancer_name" ]]; then
-  echo "$error"
+  echo "$error. ELB config differs"
   exit 1
 fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -55,6 +55,13 @@ min_max_percent=(${deployment_config//\// })
 min_deploy_perc=${min_max_percent[0]}
 max_deploy_perc=${min_max_percent[1]}
 
+if [[ $(jq '. | keys |first' $task_definition) != "0" ]]; then
+    echo "^^^"
+    echo "Invalid Task Definition"
+    echo 'JSON definition should be in the format of [{"image": "..."}]'
+    exit 1
+fi
+
 function create_service() {
     local cluster_name=$1
     local task_definition=$2

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -259,3 +259,22 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION
 }
+
+@test "Run a deploy when the container definition is incorrect" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=tests/incorrect-container-definition.json
+
+  run "$PWD/hooks/command"
+  assert_failure
+  assert_output --partial 'JSON definition should be in the format of [{"image": "..."}]'
+
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
+  unset BUILDKITE_BUILD_NUMBER
+}

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,10 +1,13 @@
 #!/usr/bin/env bats
 
+apk --no-cache add jq
+
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
 # export AWS_STUB_DEBUG=/dev/tty
-# export JQ_STUB_DEBUG=/dev/tty
+
+expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
 
 @test "Run a deploy when service exists" {
   export BUILDKITE_BUILD_NUMBER=1
@@ -14,13 +17,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
 
-  stub jq \
-    "--arg IMAGE hello-world:llamas '.[0].image=\$IMAGE' : echo '{\"json\":true}'" \
-    "'.taskDefinition.revision' : echo 1" \
-    "-r '.[0].loadBalancers[0]' : echo null"
-
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '{\"json\":true}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
@@ -33,7 +31,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Service is up 🚀"
 
   unstub aws
-  unstub jq
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
@@ -49,14 +46,10 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_1=hello-world:alpacas
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/multiple-images.json
 
-  stub jq \
-    "--arg IMAGE hello-world:llamas '.[0].image=\$IMAGE' : echo '[{\"image\":\"hello-world:llamas\"},{\"image\":\"replaceme\"}]'" \
-    "--arg IMAGE hello-world:alpacas '.[1].image=\$IMAGE' : echo '[{\"image\":\"hello-world:llamas\"},{\"image\":\"hello-world:alpacas\"}]'" \
-    "'.taskDefinition.revision' : echo 1" \
-    "-r '.[0].loadBalancers[0]' : echo null"
+  expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  },\n  {\n    "essential": true,\n    "image": "hello-world:alpacas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '[{\"image\":\"hello-world:llamas\"},{\"image\":\"hello-world:alpacas\"}]' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
@@ -69,7 +62,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Service is up 🚀"
 
   unstub aws
-  unstub jq
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
@@ -85,13 +77,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
 
-  stub jq \
-    "--arg IMAGE hello-world:llamas '.[0].image=\$IMAGE' : echo '{\"json\":true}'" \
-    "'.taskDefinition.revision' : echo 1" \
-    "-r '.[0].loadBalancers[0]' : echo null"
-
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '{\"json\":true}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
@@ -105,7 +92,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Service is up 🚀"
 
   unstub aws
-  unstub jq
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
@@ -122,13 +108,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN=arn:aws:iam::012345678910:role/world
 
-  stub jq \
-    "--arg IMAGE hello-world:llamas '.[0].image=\$IMAGE' : echo '{\"json\":true}'" \
-    "'.taskDefinition.revision' : echo 1" \
-    "-r '.[0].loadBalancers[0]' : echo null"
-
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '{\"json\":true}' --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
@@ -141,7 +122,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Service is up 🚀"
 
   unstub aws
-  unstub jq
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
@@ -160,19 +140,13 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME=nginx
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
 
-  stub jq \
-    "--arg IMAGE hello-world:llamas '.[0].image=\$IMAGE' : echo '{\"json\":true}'" \
-    "'.taskDefinition.revision' : echo 1" \
-    "-r '.[0].loadBalancers[0]' : echo alb" \
-    "-r .containerName : echo nginx" \
-    "-r .containerPort : echo 80" \
-    "-r .targetGroupArn : echo 'arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc'"
+  alb_config='[{"loadBalancers":[{"containerName":"nginx","containerPort":80,"targetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc"}]}]'
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '{\"json\":true}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers targetGroupArn=arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc,containerName=nginx,containerPort=80 : echo -n ''" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo '[{\"loadBalancerName\": \"alb\",\"containerName\": \"nginx\",\"containerPort\": 80}]'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo '$alb_config'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
     "ecs describe-services --cluster my-cluster --service my-service : echo ok"
@@ -183,7 +157,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Service is up 🚀"
 
   unstub aws
-  unstub jq
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
@@ -203,19 +176,11 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME=nginx
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
 
-  stub jq \
-    "--arg IMAGE hello-world:llamas '.[0].image=\$IMAGE' : echo '{\"json\":true}'" \
-    "'.taskDefinition.revision' : echo 1" \
-    "-r '.[0].loadBalancers[0]' : echo alb" \
-    "-r .containerName : echo nginx" \
-    "-r .containerPort : echo 80" \
-    "-r .loadBalancerName : echo nginx-elb"
-
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '{\"json\":true}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers loadBalancerName=nginx-elb,containerName=nginx,containerPort=80 : echo -n ''" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo '[{\"loadBalancerName\": \"alb\",\"containerName\": \"nginx\",\"containerPort\": 80}]'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo '[{\"loadBalancers\":[{\"loadBalancerName\": \"nginx-elb\",\"containerName\": \"nginx\",\"containerPort\": 80}]}]'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
     "ecs describe-services --cluster my-cluster --service my-service : echo ok"
@@ -226,7 +191,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Service is up 🚀"
 
   unstub aws
-  unstub jq
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
@@ -244,13 +208,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE=arn:aws:iam::012345678910:role/world
 
-  stub jq \
-    "--arg IMAGE hello-world:llamas '.[0].image=\$IMAGE' : echo '{\"json\":true}'" \
-    "'.taskDefinition.revision' : echo 1" \
-    "-r '.[0].loadBalancers[0]' : echo null"
-
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '{\"json\":true}' --execution-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
@@ -263,7 +222,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Service is up 🚀"
 
   unstub aws
-  unstub jq
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
@@ -280,13 +238,8 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION="0/100"
 
-  stub jq \
-    "--arg IMAGE hello-world:llamas '.[0].image=\$IMAGE' : echo '{\"json\":true}'" \
-    "'.taskDefinition.revision' : echo 1" \
-    "-r '.[0].loadBalancers[0]' : echo null"
-
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '{\"json\":true}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=100,minimumHealthyPercent=0 : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
@@ -300,7 +253,6 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Service is up 🚀"
 
   unstub aws
-  unstub jq
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION

--- a/tests/incorrect-container-definition.json
+++ b/tests/incorrect-container-definition.json
@@ -1,0 +1,9 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "nginx",
+      "image": "nginx",
+      "essential": true
+    }
+  ]
+}


### PR DESCRIPTION
I made some "while I'm here" changes in this PR, forgive me for mixing concerns :)

I'm a big believer in not mocking out unnecessarily and I feel that JQ being mocked out is unnecessary. It makes the tests brittle and prevents us from discovering errors in our JQ syntax, [such as this bug](https://github.com/envato/cloudformation-output-buildkite-plugin/pull/5)

Small change to improve the error we emit when we cannot set the load balancer on a service.

Finally, the reason for this PR, give the user a useful error when they provide an incorrect container definition. I considered some way of using JSON Schema but it would require installing dependencies and this seemed like the most value for money way.

cc @dferdian @lucascaton @icywednesday

