### PR TITLE
Prototype using ecs-toolkit

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -6,29 +6,6 @@ function error() {
   exit "$2"
 }
 
-# Reads either a value or a list from plugin config
-function plugin_read_list() {
-  prefix_read_list "BUILDKITE_PLUGIN_ECS_DEPLOY_$1"
-}
-
-# Reads either a value or a list from the given env prefix
-function prefix_read_list() {
-  local prefix="$1"
-  local parameter="${prefix}_0"
-
-  if [[ -n "${!parameter:-}" ]]; then
-    local i=0
-    local parameter="${prefix}_${i}"
-    while [[ -n "${!parameter:-}" ]]; do
-      echo "${!parameter}"
-      i=$((i+1))
-      parameter="${prefix}_${i}"
-    done
-  elif [[ -n "${!prefix:-}" ]]; then
-    echo "${!prefix}"
-  fi
-}
-
 function auth_ecr() {
   local docker_login
   docker_login=$(aws ecr get-login --no-include-email)

--- a/hooks/command
+++ b/hooks/command
@@ -37,5 +37,5 @@ function deploy_service() {
 }
 
 function validate_service() {
-  docker run --rm --tty 909551307430.dkr.ecr.us-east-1.amazonaws.com/ecs-toolkit:latest validate -c "${1}"
+  docker run --rm --tty -v "$(pwd)":/app -w /app 909551307430.dkr.ecr.us-east-1.amazonaws.com/ecs-toolkit:latest validate -c "${1}"
 }

--- a/hooks/command
+++ b/hooks/command
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+function error() {
+  echo "$1"
+  exit "$2"
+}
+
 # Reads either a value or a list from plugin config
 function plugin_read_list() {
   prefix_read_list "BUILDKITE_PLUGIN_ECS_DEPLOY_$1"
@@ -24,179 +29,36 @@ function prefix_read_list() {
   fi
 }
 
-cluster=${BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER?}
-task_family=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY?}
-service_name=${BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE?}
-images=()
-while read -r line ; do
-  [[ -n "$line" ]] && images+=("$line")
-done <<< "$(plugin_read_list IMAGE)"
-task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION?}
-desired_count=${BUILDKITE_PLUGIN_ECS_DEPLOY_DESIRED_COUNT:-"1"}
-task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-""}
-target_group=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP:-""}
-load_balancer_name=${BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME:-""}
-target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
-target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
-execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
-region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
-
-if [[ $region != "" ]]; then
-    AWS_DEFAULT_REGION=${region}
-fi
-
-# Resolve any runtime environment variables it has
-target_group=$(eval "echo $target_group")
-load_balancer_name=$(eval "echo $load_balancer_name")
-
-deployment_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION:-"100/200"}
-# shellcheck disable=SC2206
-min_max_percent=(${deployment_config//\// })
-min_deploy_perc=${min_max_percent[0]}
-max_deploy_perc=${min_max_percent[1]}
-
-if [[ $(jq '. | keys |first' $task_definition) != "0" ]]; then
-    echo "^^^"
-    echo "Invalid Task Definition"
-    echo 'JSON definition should be in the format of [{"image": "..."}]'
-    exit 1
-fi
-
-function create_service() {
-    local cluster_name=$1
-    local task_definition=$2
-    local service_name=$3
-    local desired_count=$4
-    local target_group_arguments
-    target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
-
-    # shellcheck disable=SC2016
-    service_defined=$(aws ecs describe-services --cluster "$cluster_name" --service "$service_name" --query 'services[?status==`ACTIVE`].status' --output text |wc -l)
-    if [[ $service_defined -eq 0 ]]; then
-        echo "--- :ecs: Creating a Service $service_name in cluster $cluster_name"
-        # shellcheck disable=SC2086
-        aws ecs create-service \
-        --cluster "$cluster_name" \
-        --service-name "$service_name" \
-        --task-definition "$task_definition" \
-        --desired-count "$desired_count" \
-        --deployment-configuration "maximumPercent=${max_deploy_perc},minimumHealthyPercent=${min_deploy_perc}" \
-        $target_group_arguments
-    fi
-}
-
-function generate_target_group_arguments() {
-    local target_group=$1
-    local target_container=$2
-    local target_port=$3
-    local target_group_arguments=""
-    if [[ -n $target_container ]] && [[ -n $target_port ]]; then
-      local load_balancer_ref=""
-      if [[ -n $target_group ]]; then
-        load_balancer_ref="targetGroupArn=${target_group}"
-      elif [[ -n $load_balancer_name ]]; then
-        load_balancer_ref="loadBalancerName=${load_balancer_name}"
-      else
-        echo "+++ ^^^"
-        # shellcheck disable=SC2016
-        echo '+++ You must specify either `target-group` or `load-balancer-name`'
-        exit 1
-      fi
-
-      target_group_arguments="--load-balancers ${load_balancer_ref},containerName=${target_container},containerPort=${target_port}"
-    fi
-    echo "$target_group_arguments"
-}
-
-## This is the template definition of your containers
-image_idx=0
-container_definitions_json=$(cat "${task_definition}")
-for image in "${images[@]}"; do
-  container_definitions_json=$(echo "$container_definitions_json" | jq --arg IMAGE "$image" \
-  ".[${image_idx}].image=\$IMAGE"
-  )
-  image_idx=$((image_idx+1))
-done
-
-echo "--- :ecs: Registering new task definition for ${task_family}"
-register_command="aws ecs register-task-definition \
-    --family ${task_family} \
-    --container-definitions '$container_definitions_json'"
-
-if [[ -n "${task_role_arn}" ]]; then
-    register_command+=" --task-role-arn ${task_role_arn}"
-fi
-
-if [[ -n "${execution_role}" ]]; then
-    register_command+=" --execution-role-arn ${execution_role}"
-fi
-
-json_output=$(eval "$register_command")
-register_exit_code=$?
-
-if [[ $register_exit_code -ne 0 ]] ; then
-  echo "+++ ^^^"
-  echo "+++ Failed to register task defintion"
-  exit "$register_exit_code"
-fi
-
-task_revision=$(jq '.taskDefinition.revision' <<< "$json_output")
-echo "Registered ${task_family}:${task_revision}"
-
-# Create service if it doesn't already exist
-create_service "$cluster" "${task_family}:${task_revision}" "$service_name" "$desired_count" "$target_group" "$target_container" "$target_port"
-
-# shellcheck disable=SC2016
-lb_config=$(aws ecs describe-services --cluster "$cluster" --services "$service_name" --query 'services[?status==`ACTIVE`]' |jq -r '.[0].loadBalancers[0]')
-error="+++ ^^^
-+++ Cannot update a service to add/remove a load balancer. First delete the service and then run again, or rename the service to force a new one to be created"
-
-# No easy way to tell if the target group has changed, since describe-services only returns the load balancer name
-if [[ "$lb_config" == "null" ]]; then
-  if [[ -n "$target_group" ]] || [[ -n "$load_balancer_name" ]]; then
-    echo "$error. ELB configured but none set in container"
-    exit 1
+function auth_ecr() {
+  local docker_login
+  docker_login=$(aws ecr get-login --no-include-email)
+  if ! eval "${docker_login}"; then
+    error "Unable to log in to ECR" 2
   fi
+}
+
+deploy_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOY_CONFIG:-""}
+validate_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_VALIDATE_CONFIG:-""}
+
+if [[ -z "${deploy_config}" && -z "${validate_config}" ]] || [[ -e "${deploy_config}" && -e "${validate_config}" ]]; then
+  error "One of either validate or deploy must be specified. See (TBA) for examples" 1
 fi
 
-if [[ "$lb_config" == "null" ]]; then
-  # noop
-  true
-elif [[ $(echo "$lb_config" |jq -r '.containerName') != "$target_container" ]] || [[ $(echo "$lb_config" |jq -r '.containerPort') -ne $target_port ]]; then
-  echo "$error. Container config differs"
-  exit 1
-elif [[ -n "$target_group" ]] && [[ $(echo "$lb_config" |jq -r '.targetGroupArn') != "$target_group" ]]; then
-  echo "$error. ALB config differs"
-  exit 1
-elif [[ -n "$load_balancer_name" ]] && [[ $(echo "$lb_config" |jq -r '.loadBalancerName') != "$load_balancer_name" ]]; then
-  echo "$error. ELB config differs"
-  exit 1
+auth_ecr
+
+if [[ -e "${deploy_config}" ]]; then
+  deploy_service "${deploy_config}"
 fi
 
-echo "--- :ecs: Updating service for ${service_name}"
-aws ecs update-service \
-  --cluster "${cluster}" \
-  --service "${service_name}" \
-  --task-definition "${task_family}:${task_revision}"
-
-## Now we wait till it's stable
-echo "--- :ecs: Waiting for services to stabilize"
-deploy_exitcode=0
-aws ecs wait services-stable \
-  --cluster "${cluster}" \
-  --services "${service_name}" || deploy_exitcode=$?
-
-
-service_events=$(aws ecs describe-services \
-  --cluster "${cluster}" \
-  --service "${service_name}" \
-  --query 'services[].events' --output text)
-
-if [[ $deploy_exitcode -eq 0 ]]; then
-  echo "--- :ecs: Service is up 🚀"
-  echo "$service_events"
-else
-  echo "+++ :ecs: Service failed to deploy ❌"
-  echo "$service_events"
-  exit $deploy_exitcode
+if [[ -e "${validate_config}" ]]; then
+  validate_service "${validate_config}"
 fi
+
+
+function deploy_service() {
+  docker run --rm --tty -v "$(pwd)":/app -w /app 909551307430.dkr.ecr.us-east-1.amazonaws.com/ecs-toolkit:latest deploy -c "${1}" --ci
+}
+
+function validate_service() {
+  docker run --rm --tty 909551307430.dkr.ecr.us-east-1.amazonaws.com/ecs-toolkit:latest validate -c "${1}"
+}

--- a/hooks/command
+++ b/hooks/command
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-function error() {
+function error_handler() {
   echo "$1"
   exit "$2"
 }
@@ -10,32 +10,50 @@ function auth_ecr() {
   local docker_login
   docker_login=$(aws ecr get-login --no-include-email)
   if ! eval "${docker_login}"; then
-    error "Unable to log in to ECR" 2
+    error_handler "Unable to log in to ECR" 2
   fi
 }
 
-deploy_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOY_CONFIG:-""}
-validate_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_VALIDATE_CONFIG:-""}
+deploy_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOY:-""}
+validate_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_VALIDATE:-""}
 
-if [[ -z "${deploy_config}" && -z "${validate_config}" ]] || [[ -e "${deploy_config}" && -e "${validate_config}" ]]; then
-  error "One of either validate or deploy must be specified. See (TBA) for examples" 1
+# If both or neither 'deploy' or 'validate' options are given, exit with an error
+if [[ -z "${deploy_config}" && -z "${validate_config}" ]] || [[ -n "${deploy_config}" && -n "${validate_config}" ]]; then
+  error_handler "One of either validate or deploy must be specified. See (TBA) for examples" 1
 fi
 
 auth_ecr
 
-if [[ -e "${deploy_config}" ]]; then
+# This pattern is borrowed from https://github.com/buildkite-plugins/artifacts-buildkite-plugin
+#
+# Use a 'configs' array to determine how many config files have been provided. For now we only support 1 but this may increase in the future.
+configs=()
+
+if [[ -n "${deploy_config}" ]]; then
+  configs+=("${deploy_config}")
+  if [[ "${#configs[@]}" -gt 1 ]]; then
+    error_handler "Only one config file is supported" 1
+  fi
   deploy_service "${deploy_config}"
-fi
-
-if [[ -e "${validate_config}" ]]; then
+elif [[ -n "${validate_config}" ]]; then
+  configs+=("${validate_config}")
+  if [[ "${#configs[@]}" -gt 1 ]]; then
+    error_handler "Only one config file is supported" 1
+  fi
   validate_service "${validate_config}"
+else
+  # This should never be reached
+  exit 1
 fi
-
 
 function deploy_service() {
-  docker run --rm --tty -v "$(pwd)":/app -w /app 909551307430.dkr.ecr.us-east-1.amazonaws.com/ecs-toolkit:latest deploy -c "${1}" --ci
-}
+  if ! docker run --rm --tty -v "$(pwd)":/app -w /app 909551307430.dkr.ecr.us-east-1.amazonaws.com/ecs-toolkit:latest deploy -c "${1}" --ci ; then
+    error_handler "ecs-deploy Buildkite plugin failed: deploy" 3
+  fi
+} 
 
 function validate_service() {
-  docker run --rm --tty -v "$(pwd)":/app -w /app 909551307430.dkr.ecr.us-east-1.amazonaws.com/ecs-toolkit:latest validate -c "${1}"
+  if ! docker run --rm --tty -v "$(pwd)":/app -w /app 909551307430.dkr.ecr.us-east-1.amazonaws.com/ecs-toolkit:latest validate -c "${1}" ; then
+    error_handler "ecs-deploy Buildkite plugin failed: validate" 3
+  fi
 }

--- a/hooks/command
+++ b/hooks/command
@@ -14,38 +14,6 @@ function auth_ecr() {
   fi
 }
 
-deploy_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOY:-""}
-validate_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_VALIDATE:-""}
-
-# If both or neither 'deploy' or 'validate' options are given, exit with an error
-if [[ -z "${deploy_config}" && -z "${validate_config}" ]] || [[ -n "${deploy_config}" && -n "${validate_config}" ]]; then
-  error_handler "One of either validate or deploy must be specified. See (TBA) for examples" 1
-fi
-
-auth_ecr
-
-# This pattern is borrowed from https://github.com/buildkite-plugins/artifacts-buildkite-plugin
-#
-# Use a 'configs' array to determine how many config files have been provided. For now we only support 1 but this may increase in the future.
-configs=()
-
-if [[ -n "${deploy_config}" ]]; then
-  configs+=("${deploy_config}")
-  if [[ "${#configs[@]}" -gt 1 ]]; then
-    error_handler "Only one config file is supported" 1
-  fi
-  deploy_service "${deploy_config}"
-elif [[ -n "${validate_config}" ]]; then
-  configs+=("${validate_config}")
-  if [[ "${#configs[@]}" -gt 1 ]]; then
-    error_handler "Only one config file is supported" 1
-  fi
-  validate_service "${validate_config}"
-else
-  # This should never be reached
-  exit 1
-fi
-
 function deploy_service() {
   if ! docker run --rm --tty -v "$(pwd)":/app -w /app 909551307430.dkr.ecr.us-east-1.amazonaws.com/ecs-toolkit:latest deploy -c "${1}" --ci ; then
     error_handler "ecs-deploy Buildkite plugin failed: deploy" 3
@@ -57,3 +25,22 @@ function validate_service() {
     error_handler "ecs-deploy Buildkite plugin failed: validate" 3
   fi
 }
+
+deploy_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOY:-""}
+validate_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_VALIDATE:-""}
+
+# If both or neither 'deploy' or 'validate' options are given, exit with an error
+if [[ -z "${deploy_config}" && -z "${validate_config}" ]] || [[ -n "${deploy_config}" && -n "${validate_config}" ]]; then
+  error_handler "One of either validate or deploy must be specified. See (TBA) for examples" 1
+fi
+
+auth_ecr
+
+if [[ -n "${deploy_config}" ]]; then
+  deploy_service "${deploy_config}"
+elif [[ -n "${validate_config}" ]]; then
+  validate_service "${validate_config}"
+else
+  # This should never be reached
+  exit 1
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,9 +7,9 @@ requirements:
 configuration:
   properties:
     deploy:
-      type: [ string, array ]
+      type: string
     validate:
-      type: [ string, array ]
+      type: string
   oneOf:
     - required:
       - deploy

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,40 +1,17 @@
 name: ECS Deploy
 description: Deploy to ECS
-author: https://github.com/buildkite
+author: https://github.com/envato
 requirements:
   - aws
-  - jq
+  - docker
 configuration:
   properties:
-    cluster:
-      type: string
-    service:
-      type: string
-    task-definition:
-      type: string
-    task-family:
-      type: string
-    image:
+    deploy:
       type: [ string, array ]
-    desired-count:
-      type: string
-    task-role-arn:
-      type: string
-    target-group:
-      type: string
-    load-balanccer-name:
-      type: string
-    target-container-name:
-      type: string
-    target-container-port:
-      type: integer
-    execution-role:
-      type: string
-    deployment-config:
-      type: string
-  required:
-    - cluster
-    - service
-    - task-definition
-    - task-family
-    - image
+    validate:
+      type: [ string, array ]
+  oneOf:
+    - required:
+      - deploy
+    - required:
+      - validate

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -7,274 +7,65 @@ load '/usr/local/lib/bats/load.bash'
 # Uncomment to enable stub debug output:
 # export AWS_STUB_DEBUG=/dev/tty
 
-expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
-
-@test "Run a deploy when service exists" {
+@test "Fail when multiple config paths are given" {
   export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
-
-  stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo '1'" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service : echo ok"
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOY="path/to/config1.json"
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_VALIDATE="path/to/config1.json"
 
   run "$PWD/hooks/command"
 
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
-}
-
-@test "Run a deploy with multiple images" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_0=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_1=hello-world:alpacas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/multiple-images.json
-
-  expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  },\n  {\n    "essential": true,\n    "image": "hello-world:alpacas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
-
-  stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo '1'" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_0
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_1
-}
-
-@test "Run a deploy when service does not exist" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
-
-  stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo -n ''" \
-    "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 : echo -n ''" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
-}
-
-@test "Run a deploy with task role" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN=arn:aws:iam::012345678910:role/world
-
-  stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo '1'" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN
-}
-
-@test "Run a deploy with target group" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP=arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME=nginx
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
-
-  alb_config='[{"loadBalancers":[{"containerName":"nginx","containerPort":80,"targetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc"}]}]'
-
-  stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo -n ''" \
-    "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers targetGroupArn=arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc,containerName=nginx,containerPort=80 : echo -n ''" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo '$alb_config'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT
-}
-
-@test "Run a deploy with ELBv1" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME=nginx-elb
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME=nginx
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
-
-  stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo -n ''" \
-    "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers loadBalancerName=nginx-elb,containerName=nginx,containerPort=80 : echo -n ''" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo '[{\"loadBalancers\":[{\"loadBalancerName\": \"nginx-elb\",\"containerName\": \"nginx\",\"containerPort\": 80}]}]'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME
-}
-
-@test "Run a deploy with execution role" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE=arn:aws:iam::012345678910:role/world
-
-  stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo '1'" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE
-}
-
-@test "Create a service with deployment configuration" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION="0/100"
-
-  stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo -n ''" \
-    "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=100,minimumHealthyPercent=0 : echo -n ''" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION
-}
-
-@test "Run a deploy when the container definition is incorrect" {
-  export BUILDKITE_BUILD_NUMBER=1
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=tests/incorrect-container-definition.json
-
-  run "$PWD/hooks/command"
   assert_failure
-  assert_output --partial 'JSON definition should be in the format of [{"image": "..."}]'
+  assert_output --partial "One of either validate or deploy must be specified"
 
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
-  unset BUILDKITE_BUILD_NUMBER
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOY
+}
+
+@test "Fail when no config paths are given" {
+  export BUILDKITE_BUILD_NUMBER=1
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "One of either validate or deploy must be specified"
+}
+
+# The below two tests assert failure as the error thrown from the docker command
+# is the simplest way of distinguising which function has been called
+
+@test "A deploy config is passed to the deploy command" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOY="path/to/config.json"
+
+  stub aws \
+    "ecr get-login --no-include-email : echo true"
+
+  stub docker \
+    "run --rm --tty -v /plugin:/app -w /app 909551307430.dkr.ecr.us-east-1.amazonaws.com/ecs-toolkit:latest deploy -c path/to/config.json --ci : exit 1"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "ecs-deploy Buildkite plugin failed: deploy"
+
+  unstub aws
+  unstub docker
+}
+
+@test "A validate config is passed to the validate command" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_VALIDATE="path/to/config.json"
+
+  stub aws \
+    "ecr get-login --no-include-email : echo true"
+
+  stub docker \
+    "run --rm --tty -v /plugin:/app -w /app 909551307430.dkr.ecr.us-east-1.amazonaws.com/ecs-toolkit:latest validate -c path/to/config.json : exit 1"
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "ecs-deploy Buildkite plugin failed: validate"
+
+  unstub aws
+  unstub docker
 }


### PR DESCRIPTION
This PR updates Envato's ecs-deploy Buildkite plugin to use `ecs-toolkit`. This is currently for testing purposes and therefore only supported for agents on the `platform-docker-spot` queue; only they have access to the ECR repository containing the `ecs-toolkit` image.

The configuration file format is also now slightly expanded, see https://github.com/envato/ecs-toolkit for more information.

The plugin offers two options, `validate` and `deploy`: 

- `validate`: Runs placement checks against the provided config file and determines whether the service can be deployed to the chosen cluster. Intended to be run across all branches.
- `deploy`: Runs a deployment using a very similar process to the existing plugin. Intended to be run on master branch.

Running both of these options in one build step is unsupported.

```yaml
- name: ":ecs: Validate service"
   plugins:
   - envato/ecs-deploy#v1.0.0:
         validate: path/to/config.json
   agents:
       queue: platform-docker-spot
```

```yaml
- name: ":ecs: Deploy service"
   branches: master
   plugins:
   - envato/ecs-deploy#v1.0.0:
         deploy: path/to/config.json
   agents:
       queue: platform-docker-spot
```