### PR TITLE
Fargate support; requires-compatibilities, network-mode etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Example: `"0/100"`
 
 The region we deploy the ECS Service to.
 
+### `requires-compatibilities` (optional)
+
+The launch type the task requires. If no value is specified, it will default to EC2. Valid values include EC2 and FARGATE.
+
+Example: `"FARGATE"`
+
 ## AWS Roles
 
 At a minimum this plugin requires the following AWS permissions to be granted to the agent running this step:

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ The launch type the task requires. If no value is specified, it will default to 
 
 Example: `"FARGATE"`
 
+### `network-mode` (optional)
+
+The Docker networking mode to use for the containers in the task. The valid values are `none`, `bridge`, `awsvpc`, and `host`. The default Docker network mode is `bridge`.
+
+Example: `"awsvpc"`
+
 ## AWS Roles
 
 At a minimum this plugin requires the following AWS permissions to be granted to the agent running this step:

--- a/hooks/command
+++ b/hooks/command
@@ -131,10 +131,12 @@ if [[ -n "${task_role_arn}" ]]; then
 fi
 
 if [[ -n "${execution_role}" ]]; then
+    echo "--- :ecs: execution_role ${execution_role}"
     register_command+=" --execution-role-arn ${execution_role}"
 fi
 
 if [[ -n "${requires_compatibilities}" ]]; then
+    echo "--- :ecs: requires_compatibilities ${requires_compatibilities}"
     register_command+=" --requires-compatibilities ${requires_compatibilities}"
 fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -206,7 +206,7 @@ echo "--- :ecs: Waiting for services to stabilize"
 deploy_exitcode=0
 aws ecs wait services-stable \
   --cluster "${cluster}" \
-  --service "${service_name}" || deploy_exitcode=$?
+  --services "${service_name}" || deploy_exitcode=$?
 
 
 service_events=$(aws ecs describe-services \

--- a/hooks/command
+++ b/hooks/command
@@ -196,4 +196,29 @@ elif [[ -n "$load_balancer_name" ]] && [[ $(echo "$lb_config" |jq -r '.loadBalan
   exit 1
 fi
 
+echo "--- :ecs: Updating service for ${service_name}"
+echo "for cluster: ${cluster}"
+echo "revision: ${task_family}:${task_revision}"
+aws ecs update-service --cluster "${cluster}" --service "${service_name}" --task-definition "${task_family}:${task_revision}"
 
+## Now we wait till it's stable
+echo "--- :ecs: Waiting for services to stabilize"
+deploy_exitcode=0
+aws ecs wait services-stable \
+  --cluster "${cluster}" \
+  --service "${service_name}" || deploy_exitcode=$?
+
+
+service_events=$(aws ecs describe-services \
+  --cluster "${cluster}" \
+  --service "${service_name}" \
+  --query 'services[].events' --output text)
+
+if [[ $deploy_exitcode -eq 0 ]]; then
+  echo "--- :ecs: Service is up 🚀"
+  echo "$service_events"
+else
+  echo "+++ :ecs: Service failed to deploy ❌"
+  echo "$service_events"
+  exit $deploy_exitcode
+fi

--- a/hooks/command
+++ b/hooks/command
@@ -186,6 +186,9 @@ if [[ "$lb_config" == "null" ]]; then
   # noop
   true
 elif [[ $(echo "$lb_config" |jq -r '.containerName') != "$target_container" ]] || [[ $(echo "$lb_config" |jq -r '.containerPort') -ne $target_port ]]; then
+  echo "$lb_config"
+  echo "$target_container"
+  echo "$target_port"
   echo "$error. Container config differs"
   exit 1
 elif [[ -n "$target_group" ]] && [[ $(echo "$lb_config" |jq -r '.targetGroupArn') != "$target_group" ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -139,6 +139,7 @@ if [[ -n "${requires_compatibilities}" ]]; then
 fi
 
 if [[ -n "${network_mode}" ]]; then
+    echo "--- :ecs: Using network mode ${network_mode}"
     register_command+=" --network-mode ${network_mode}"
 fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -79,6 +79,7 @@ function create_service() {
     echo $cluster_name
     echo $service_name
     service_defined=$(aws ecs describe-services --cluster "$cluster_name" --service "$service_name" --query 'services[?status==`ACTIVE`].status' --output text |wc -l)
+    echo $service_defined
     if [[ $service_defined -eq 0 ]]; then
         echo "--- :ecs: Creating a Service $service_name in cluster $cluster_name"
         # shellcheck disable=SC2086

--- a/hooks/command
+++ b/hooks/command
@@ -49,7 +49,6 @@ if [[ $region != "" ]]; then
   # shellcheck disable=SC2034 # Used by the aws cli
   AWS_DEFAULT_REGION=${region}
 fi
-echo ${AWS_DEFAULT_REGION}
 
 # Resolve any runtime environment variables it has
 target_group=$(eval "echo $target_group")
@@ -198,10 +197,10 @@ elif [[ -n "$load_balancer_name" ]] && [[ $(echo "$lb_config" |jq -r '.loadBalan
 fi
 
 echo "--- :ecs: Updating service for ${service_name}"
-aws ecs update-service \
-  --cluster "${cluster}" \
-  --service "${service_name}" \
-  --task-definition "${task_family}:${task_revision}"
+echo "for cluster: ${cluster}"
+echo "revision: ${task_family}:${task_revision}"
+aws ecs update-service --cluster "${cluster}" --service "${service_name}" --task-definition "${task_family}:${task_revision}"
+echo "test"
 
 ## Now we wait till it's stable
 echo "--- :ecs: Waiting for services to stabilize"

--- a/hooks/command
+++ b/hooks/command
@@ -40,6 +40,7 @@ target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
 target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
 execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
 region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
+requires_compatibilities=${BUILDKITE_PLUGIN_ECS_DEPLOY_REQUIRES_COMPATIBILITIES:-""}
 
 if [[ $region != "" ]]; then
   # shellcheck disable=SC2034 # Used by the aws cli
@@ -130,6 +131,10 @@ fi
 
 if [[ -n "${execution_role}" ]]; then
     register_command+=" --execution-role-arn ${execution_role}"
+fi
+
+if [[ -n "${requires_compatibilities}" ]]; then
+    register_command+=" --requires-compatibilities ${requires_compatibilities}"
 fi
 
 json_output=$(eval "$register_command")

--- a/hooks/command
+++ b/hooks/command
@@ -199,7 +199,7 @@ fi
 echo "--- :ecs: Updating service for ${service_name}"
 echo "for cluster: ${cluster}"
 echo "revision: ${task_family}:${task_revision}"
-aws ecs update-service --cluster "${cluster}" --service "${service_name}" --task-definition "${task_family}:${task_revision}"
+aws ecs update-service --cluster "${cluster}" --service "${service_name}" --task-definition "${task_family}:${task_revision}" > /dev/null
 
 ## Now we wait till it's stable
 echo "--- :ecs: Waiting for services to stabilize"

--- a/hooks/command
+++ b/hooks/command
@@ -41,6 +41,7 @@ target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
 execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
 region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
 requires_compatibilities=${BUILDKITE_PLUGIN_ECS_DEPLOY_REQUIRES_COMPATIBILITIES:-""}
+network_mode=${BUILDKITE_PLUGIN_ECS_DEPLOY_NETWORK_MODE:-""}
 
 if [[ $region != "" ]]; then
   # shellcheck disable=SC2034 # Used by the aws cli
@@ -135,6 +136,10 @@ fi
 
 if [[ -n "${requires_compatibilities}" ]]; then
     register_command+=" --requires-compatibilities ${requires_compatibilities}"
+fi
+
+if [[ -n "${network_mode}" ]]; then
+    register_command+=" --network-mode ${network_mode}"
 fi
 
 json_output=$(eval "$register_command")

--- a/hooks/command
+++ b/hooks/command
@@ -49,6 +49,7 @@ if [[ $region != "" ]]; then
   # shellcheck disable=SC2034 # Used by the aws cli
   AWS_DEFAULT_REGION=${region}
 fi
+echo ${AWS_DEFAULT_REGION}
 
 # Resolve any runtime environment variables it has
 target_group=$(eval "echo $target_group")
@@ -189,8 +190,6 @@ elif [[ $(echo "$lb_config" |jq -r '.containerName') != "$target_container" ]] |
   echo "$error. Container config differs"
   exit 1
 elif [[ -n "$target_group" ]] && [[ $(echo "$lb_config" |jq -r '.targetGroupArn') != "$target_group" ]]; then
-  echo "$lb_config"
-  echo "$target_group"
   echo "$error. ALB config differs"
   exit 1
 elif [[ -n "$load_balancer_name" ]] && [[ $(echo "$lb_config" |jq -r '.loadBalancerName') != "$load_balancer_name" ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -42,6 +42,8 @@ execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
 region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
 requires_compatibilities=${BUILDKITE_PLUGIN_ECS_DEPLOY_REQUIRES_COMPATIBILITIES:-""}
 network_mode=${BUILDKITE_PLUGIN_ECS_DEPLOY_NETWORK_MODE:-""}
+task_cpu=${BUILDKITE_PLUGIN_ECS_DEPLOY_CPU:-""}
+task_memory=${BUILDKITE_PLUGIN_ECS_DEPLOY_MEMORY:-""}
 
 if [[ $region != "" ]]; then
   # shellcheck disable=SC2034 # Used by the aws cli
@@ -131,19 +133,26 @@ if [[ -n "${task_role_arn}" ]]; then
 fi
 
 if [[ -n "${execution_role}" ]]; then
-    echo "--- :ecs: execution_role ${execution_role}"
     register_command+=" --execution-role-arn ${execution_role}"
 fi
 
 if [[ -n "${requires_compatibilities}" ]]; then
-    echo "--- :ecs: requires_compatibilities ${requires_compatibilities}"
     register_command+=" --requires-compatibilities ${requires_compatibilities}"
 fi
 
 if [[ -n "${network_mode}" ]]; then
-    echo "--- :ecs: Using network mode ${network_mode}"
     register_command+=" --network-mode ${network_mode}"
 fi
+
+if [[ -n "${task_cpu}" ]]; then
+    register_command+=" --cpu ${task_cpu}"
+fi
+
+if [[ -n "${task_memory}" ]]; then
+    register_command+=" --memory ${task_memory}"
+fi
+
+echo "--- :ecs: task register command: ${register_command}"
 
 json_output=$(eval "$register_command")
 register_exit_code=$?

--- a/hooks/command
+++ b/hooks/command
@@ -186,12 +186,11 @@ if [[ "$lb_config" == "null" ]]; then
   # noop
   true
 elif [[ $(echo "$lb_config" |jq -r '.containerName') != "$target_container" ]] || [[ $(echo "$lb_config" |jq -r '.containerPort') -ne $target_port ]]; then
-  echo "$lb_config"
-  echo "$target_container"
-  echo "$target_port"
   echo "$error. Container config differs"
   exit 1
 elif [[ -n "$target_group" ]] && [[ $(echo "$lb_config" |jq -r '.targetGroupArn') != "$target_group" ]]; then
+  echo "$lb_config"
+  echo "$target_group"
   echo "$error. ALB config differs"
   exit 1
 elif [[ -n "$load_balancer_name" ]] && [[ $(echo "$lb_config" |jq -r '.loadBalancerName') != "$load_balancer_name" ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -196,30 +196,4 @@ elif [[ -n "$load_balancer_name" ]] && [[ $(echo "$lb_config" |jq -r '.loadBalan
   exit 1
 fi
 
-echo "--- :ecs: Updating service for ${service_name}"
-echo "for cluster: ${cluster}"
-echo "revision: ${task_family}:${task_revision}"
-aws ecs update-service --cluster "${cluster}" --service "${service_name}" --task-definition "${task_family}:${task_revision}"
-echo "test"
 
-## Now we wait till it's stable
-echo "--- :ecs: Waiting for services to stabilize"
-deploy_exitcode=0
-aws ecs wait services-stable \
-  --cluster "${cluster}" \
-  --services "${service_name}" || deploy_exitcode=$?
-
-
-service_events=$(aws ecs describe-services \
-  --cluster "${cluster}" \
-  --service "${service_name}" \
-  --query 'services[].events' --output text)
-
-if [[ $deploy_exitcode -eq 0 ]]; then
-  echo "--- :ecs: Service is up 🚀"
-  echo "$service_events"
-else
-  echo "+++ :ecs: Service failed to deploy ❌"
-  echo "$service_events"
-  exit $deploy_exitcode
-fi

--- a/hooks/command
+++ b/hooks/command
@@ -76,6 +76,8 @@ function create_service() {
     target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
 
     # shellcheck disable=SC2016
+    echo $cluster_name
+    echo $service_name
     service_defined=$(aws ecs describe-services --cluster "$cluster_name" --service "$service_name" --query 'services[?status==`ACTIVE`].status' --output text |wc -l)
     if [[ $service_defined -eq 0 ]]; then
         echo "--- :ecs: Creating a Service $service_name in cluster $cluster_name"

--- a/hooks/command
+++ b/hooks/command
@@ -76,10 +76,7 @@ function create_service() {
     target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
 
     # shellcheck disable=SC2016
-    echo $cluster_name
-    echo $service_name
     service_defined=$(aws ecs describe-services --cluster "$cluster_name" --service "$service_name" --query 'services[?status==`ACTIVE`].status' --output text |wc -l)
-    echo $service_defined
     if [[ $service_defined -eq 0 ]]; then
         echo "--- :ecs: Creating a Service $service_name in cluster $cluster_name"
         # shellcheck disable=SC2086


### PR DESCRIPTION
Added 'requires-compatibilities' parameter to the `register-task-definition` command. Otherwise, FARGATE tasks cannot be launched throwing: 

```An error occurred (InvalidParameterException) when calling the UpdateService operation: Task definition does not support launch_type FARGATE```

( https://github.com/aws/aws-cli/issues/3983 )