### PR TITLE
tests: `apk add jq` once only, not once per test.

### DIFF
--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,8 +1,16 @@
 #!/usr/bin/env bats
 
-apk --no-cache add jq
-
 load '/usr/local/lib/bats/load.bash'
+
+setup() {
+  # emulate the upcoming bats `setup_file`
+  # https://github.com/bats-core/bats-core/issues/39#issuecomment-377015447
+  if [[ $BATS_TEST_NUMBER -eq 1 ]]; then
+    # output to fd 3, prefixed with hashes, for TAP compliance:
+    # https://github.com/bats-core/bats-core/blob/v1.2.0/README.md#printing-to-the-terminal
+    apk --no-cache add jq | sed -e 's/^/# /' >&3
+  fi
+}
 
 # Uncomment to enable stub debug output:
 # export AWS_STUB_DEBUG=/dev/tty


### PR DESCRIPTION
The installation of `jq` was being attempted before each test in the suite. This added time and noise.

Getting our version of BATS to run a setup-once function is trickier than expected.
This PR uses `setup` (per test) combined with `$BATS_TEST_NUMBER` to only run on the first test, as suggested in https://github.com/bats-core/bats-core/issues/39#issuecomment-377015447

It looks like `setup_file` was merged in https://github.com/bats-core/bats-core/pull/244 but I don't know what version that landed in nor really what version we're using, but it doesn't seem to be available to us.

### Before

```
pda@paulbookpro ~/bk/plugins/ecs-deploy-buildkite-plugin ❯ docker run --rm -v $(pwd):/plugin:ro buildkite/plugin-tester
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
OK: 15 MiB in 25 packages
1..9
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
OK: 15 MiB in 25 packages
ok 1 Run a deploy when service exists
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
OK: 15 MiB in 25 packages
ok 2 Run a deploy with multiple images
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
OK: 15 MiB in 25 packages
ok 3 Run a deploy when service does not exist
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
OK: 15 MiB in 25 packages
ok 4 Run a deploy with task role
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
OK: 15 MiB in 25 packages
ok 5 Run a deploy with target group
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
OK: 15 MiB in 25 packages
ok 6 Run a deploy with ELBv1
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
OK: 15 MiB in 25 packages
ok 7 Run a deploy with execution role
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
OK: 15 MiB in 25 packages
ok 8 Create a service with deployment configuration
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
OK: 15 MiB in 25 packages
ok 9 Run a deploy when the container definition is incorrect
```

### After

```
pda@paulbookpro ~/bk/plugins/ecs-deploy-buildkite-plugin ❯ docker run --rm -v $(pwd):/plugin:ro buildkite/plugin-tester
1..9
# fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
# fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
# OK: 15 MiB in 25 packages
ok 1 Run a deploy when service exists
ok 2 Run a deploy with multiple images
ok 3 Run a deploy when service does not exist
ok 4 Run a deploy with task role
ok 5 Run a deploy with target group
ok 6 Run a deploy with ELBv1
ok 7 Run a deploy with execution role
ok 8 Create a service with deployment configuration
ok 9 Run a deploy when the container definition is incorrect
```