### PR TITLE
Enable use of true task definitions + service definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ steps:
       - ecs-deploy#v1.4.1:
           cluster: "my-ecs-cluster"
           service: "my-service"
-          task-definition: "examples/hello-world.json"
+          container-definitions: "examples/hello-world.json"
           task-family: "hello-world"
           image: "${ECR_REPOSITORY}/hello-world:${BUILDKITE_BUILD_NUMBER}"
 ```
@@ -37,11 +37,50 @@ The name of the ECS service.
 
 Example: `"my-service"`
 
+### `container-definitions`
+
+The file path to the ECS container definition JSON file. This JSON file must be an array of objects, each corresponding to one of the images you defined in the `image` parameter.
+
+Example: `"ecs/containers.json"`
+```json
+[
+    {
+        "essential": true,
+        "image": "amazon/amazon-ecs-sample",
+        "memory": 100,
+        "name": "sample",
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 80
+            }
+        ]
+    },
+    {
+        "essential": true,
+        "image": "amazon/amazon-ecs-sample",
+        "memory": 100,
+        "name": "sample",
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 80
+            }
+        ]
+    }
+]
+```
+
 ### `task-definition`
 
-The file path to the ECS task definition JSON file.
+The file path to the ECS task definition JSON file. Parameters specified in this file will be overridden by other arguments if set. Setting the `containers` property in this file will have no effect, define those parameters in `container-definitions`
 
 Example: `"ecs/task.json"`
+```json
+{
+  "networkMode": "awsvpc"
+}
+```
 
 ### `task-family`
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Example: `"0/100"`
 
 The region we deploy the ECS Service to.
 
+### `env` (optional)
+
+An array of environment variables to add to *every* image's task definition
+
 ## AWS Roles
 
 At a minimum this plugin requires the following AWS permissions to be granted to the agent running this step:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ Example: `"ecs/task.json"`
 }
 ```
 
+### `service-definition`
+
+The file path to the ECS service definition JSON file. Parameters specified in this file will be overridden by other arguments if set, e.g. `cluster`, `desired-count`, etc. Note that currently this json input will only be used when creating the service, NOT when updating it.
+
+Example: `"ecs/service.json"`
+```json
+{
+  "schedulingStrategy": "DAEMON",
+  "propagateTags": "TASK_DEFINITION"
+}
+```
+
 ### `task-family`
 
 The name of the task family.

--- a/examples/task-definition.json
+++ b/examples/task-definition.json
@@ -1,0 +1,3 @@
+{
+    "networkMode": "awsvpc"
+}

--- a/hooks/command
+++ b/hooks/command
@@ -40,6 +40,7 @@ target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
 target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
 execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
 region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
+env_file_url=${BUILDKITE_PLUGIN_ECS_DEPLOY_ENV_FILE_URL:-""}
 
 if [[ $region != "" ]]; then
   # shellcheck disable=SC2034 # Used by the aws cli
@@ -118,6 +119,9 @@ for image in "${images[@]}"; do
   )
   image_idx=$((image_idx+1))
 done
+
+echo "--- :thisisfine: "
+echo "$container_definitions_json"
 
 echo "--- :ecs: Registering new task definition for ${task_family}"
 register_command="aws ecs register-task-definition \

--- a/hooks/command
+++ b/hooks/command
@@ -31,7 +31,7 @@ images=()
 while read -r line ; do
   [[ -n "$line" ]] && images+=("$line")
 done <<< "$(plugin_read_list IMAGE)"
-task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION?}
+task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION:-""}
 container_definitions=${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS?}
 desired_count=${BUILDKITE_PLUGIN_ECS_DEPLOY_DESIRED_COUNT:-"1"}
 task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-""}

--- a/hooks/command
+++ b/hooks/command
@@ -126,14 +126,13 @@ done
 ## This adds the env vars to each container
 echo "--- :thisisfine: attempting env var load"
 image_idx=0
-container_definitions_json=$(cat "${task_definition}")
 for image in "${images[@]}"; do
   container_definitions_json=$(echo "$container_definitions_json" | jq ".[${image_idx}].environment=[]"
   )
   for env_var in "${env_vars[@]}"; do
     # shellcheck disable=SC2206
     var_val=(${env_var//=/ })
-    container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "$var_val[0]" --arg ENVVAL "$var_val[1]" \
+    container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "${var_val[0]}" --arg ENVVAL "${var_val[1]}" \
       ".[${image_idx}].environment += [{\"name\": \$ENVVAR, \"value\": \$ENVVAL}]"
     )
   done

--- a/hooks/command
+++ b/hooks/command
@@ -126,8 +126,6 @@ done
 ## This adds the env vars to each container
 image_idx=0
 for image in "${images[@]}"; do
-  container_definitions_json=$(echo "$container_definitions_json" | jq ".[${image_idx}].environment=[]"
-  )
   for env_var in "${env_vars[@]}"; do
     # shellcheck disable=SC2206
     var_val=(${env_var//=/ })

--- a/hooks/command
+++ b/hooks/command
@@ -134,7 +134,7 @@ for image in "${images[@]}"; do
     # shellcheck disable=SC2206
     var_val=(${env_var//=/ })
     container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "$var_val[0]" --arg ENVVAL "$var_val[1]" \
-      '.[${image_idx}].environment += {"name": \$ENVVAR, "value": \$ENVVAL}'
+      ".[${image_idx}].environment += [{\"name\": \$ENVVAR, \"value\": \$ENVVAL}]"
     )
   done
   image_idx=$((image_idx+1))

--- a/hooks/command
+++ b/hooks/command
@@ -124,6 +124,7 @@ for image in "${images[@]}"; do
 done
 
 ## This adds the env vars to each container
+echo "--- :thisisfine: attempting env var load"
 image_idx=0
 container_definitions_json=$(cat "${task_definition}")
 for image in "${images[@]}"; do

--- a/hooks/command
+++ b/hooks/command
@@ -32,6 +32,7 @@ while read -r line ; do
   [[ -n "$line" ]] && images+=("$line")
 done <<< "$(plugin_read_list IMAGE)"
 task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION?}
+container_definitions=${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS?}
 desired_count=${BUILDKITE_PLUGIN_ECS_DEPLOY_DESIRED_COUNT:-"1"}
 task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-""}
 target_group=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP:-""}
@@ -60,9 +61,9 @@ min_max_percent=(${deployment_config//\// })
 min_deploy_perc=${min_max_percent[0]}
 max_deploy_perc=${min_max_percent[1]}
 
-if [[ $(jq '. | keys |first' "$task_definition") != "0" ]]; then
+if [[ $(jq '. | keys |first' "$container_definitions") != "0" ]]; then
     echo "^^^"
-    echo "Invalid Task Definition"
+    echo "Invalid Container Definitions"
     echo 'JSON definition should be in the format of [{"image": "..."}]'
     exit 1
 fi
@@ -115,7 +116,7 @@ function generate_target_group_arguments() {
 
 ## This is the template definition of your containers
 image_idx=0
-container_definitions_json=$(cat "${task_definition}")
+container_definitions_json=$(cat "${container_definitions}")
 for image in "${images[@]}"; do
   container_definitions_json=$(echo "$container_definitions_json" | jq --arg IMAGE "$image" \
   ".[${image_idx}].image=\$IMAGE"
@@ -148,6 +149,14 @@ fi
 if [[ -n "${execution_role}" ]]; then
     register_command+=" --execution-role-arn ${execution_role}"
 fi
+
+if [[ -n "${task_definition}" ]]; then
+    task_definition_json=$(cat "${task_definition}")
+    register_command+=" --cli-input-json '$task_definition_json'"
+fi
+
+echo "--- :ecs: register command:"
+echo $register_command
 
 json_output=$(eval "$register_command")
 register_exit_code=$?

--- a/hooks/command
+++ b/hooks/command
@@ -124,7 +124,6 @@ for image in "${images[@]}"; do
 done
 
 ## This adds the env vars to each container
-echo "--- :thisisfine: attempting env var load"
 image_idx=0
 for image in "${images[@]}"; do
   container_definitions_json=$(echo "$container_definitions_json" | jq ".[${image_idx}].environment=[]"
@@ -138,9 +137,6 @@ for image in "${images[@]}"; do
   done
   image_idx=$((image_idx+1))
 done
-
-echo "--- :thisisfine: "
-echo "$container_definitions_json"
 
 echo "--- :ecs: Registering new task definition for ${task_family}"
 register_command="aws ecs register-task-definition \

--- a/hooks/command
+++ b/hooks/command
@@ -40,7 +40,10 @@ target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
 target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
 execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
 region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
-env_file_url=${BUILDKITE_PLUGIN_ECS_DEPLOY_ENV_FILE_URL:-""}
+env_vars=()
+while read -r line ; do
+  [[ -n "$line" ]] && images+=("$line")
+done <<< "$(plugin_read_list ENV)"
 
 if [[ $region != "" ]]; then
   # shellcheck disable=SC2034 # Used by the aws cli
@@ -117,6 +120,22 @@ for image in "${images[@]}"; do
   container_definitions_json=$(echo "$container_definitions_json" | jq --arg IMAGE "$image" \
   ".[${image_idx}].image=\$IMAGE"
   )
+  image_idx=$((image_idx+1))
+done
+
+## This adds the env vars to each container
+image_idx=0
+container_definitions_json=$(cat "${task_definition}")
+for image in "${images[@]}"; do
+  container_definitions_json=$(echo "$container_definitions_json" | jq ".[${image_idx}].environment=[]"
+  )
+  for env_var in "${env_vars[@]}"; do
+    # shellcheck disable=SC2206
+    var_val=(${env_var//=/ })
+    container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "$var_val[0]" --arg ENVVAL "$var_val[1]" \
+      ".[${image_idx}].environment += {'name': \$ENVVAR, value: \$ENVVAL}"
+    )
+  done
   image_idx=$((image_idx+1))
 done
 

--- a/hooks/command
+++ b/hooks/command
@@ -134,7 +134,7 @@ for image in "${images[@]}"; do
     # shellcheck disable=SC2206
     var_val=(${env_var//=/ })
     container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "$var_val[0]" --arg ENVVAL "$var_val[1]" \
-      ".[${image_idx}].environment += {'name': \$ENVVAR, 'value': \$ENVVAL}"
+      '.[${image_idx}].environment += {"name": \$ENVVAR, "value": \$ENVVAL}'
     )
   done
   image_idx=$((image_idx+1))

--- a/hooks/command
+++ b/hooks/command
@@ -181,6 +181,12 @@ create_service "$cluster" "${task_family}:${task_revision}" "$service_name" "$de
 
 # shellcheck disable=SC2016
 lb_config=$(aws ecs describe-services --cluster "$cluster" --services "$service_name" --query 'services[?status==`ACTIVE`]' |jq -r '.[0].loadBalancers[0]')
+echo "load balance config"
+echo "$lb_config"
+echo "$(echo "$lb_config" |jq -r '.containerName')"
+echo "$target_container"
+echo "$(echo "$lb_config" |jq -r '.containerPort')"
+echo "$target_port"
 error="+++ ^^^
 +++ Cannot update a service to add/remove a load balancer. First delete the service and then run again, or rename the service to force a new one to be created"
 

--- a/hooks/command
+++ b/hooks/command
@@ -42,7 +42,7 @@ execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
 region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
 env_vars=()
 while read -r line ; do
-  [[ -n "$line" ]] && images+=("$line")
+  [[ -n "$line" ]] && env_vars+=("$line")
 done <<< "$(plugin_read_list ENV)"
 
 if [[ $region != "" ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -32,6 +32,7 @@ while read -r line ; do
   [[ -n "$line" ]] && images+=("$line")
 done <<< "$(plugin_read_list IMAGE)"
 task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION:-""}
+service_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE_DEFINITION:-""}
 container_definitions=${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS?}
 desired_count=${BUILDKITE_PLUGIN_ECS_DEPLOY_DESIRED_COUNT:-"1"}
 task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-""}
@@ -75,6 +76,11 @@ function create_service() {
     local desired_count=$4
     local target_group_arguments
     target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
+    
+    local service_definition_json="{}"
+    if [[ -n "${service_definition}" ]]; then
+      service_definition_json=$(cat "${service_definition}")
+    fi
 
     # shellcheck disable=SC2016
     service_defined=$(aws ecs describe-services --cluster "$cluster_name" --service "$service_name" --query 'services[?status==`ACTIVE`].status' --output text |wc -l)
@@ -87,7 +93,8 @@ function create_service() {
         --task-definition "$task_definition" \
         --desired-count "$desired_count" \
         --deployment-configuration "maximumPercent=${max_deploy_perc},minimumHealthyPercent=${min_deploy_perc}" \
-        $target_group_arguments
+        $target_group_arguments \
+        --cli-input-json service_definition_json
     fi
 }
 
@@ -152,11 +159,10 @@ fi
 
 if [[ -n "${task_definition}" ]]; then
     task_definition_json=$(cat "${task_definition}")
-    register_command+=" --cli-input-json '$task_definition_json'"
+    register_command+=" --cli-input-json '${task_definition_json}'"
 fi
 
 echo "--- :ecs: register command:"
-echo $register_command
 
 json_output=$(eval "$register_command")
 register_exit_code=$?

--- a/hooks/command
+++ b/hooks/command
@@ -94,7 +94,7 @@ function create_service() {
         --desired-count "$desired_count" \
         --deployment-configuration "maximumPercent=${max_deploy_perc},minimumHealthyPercent=${min_deploy_perc}" \
         $target_group_arguments \
-        --cli-input-json service_definition_json
+        --cli-input-json "$service_definition_json"
     fi
 }
 

--- a/hooks/command
+++ b/hooks/command
@@ -134,7 +134,7 @@ for image in "${images[@]}"; do
     # shellcheck disable=SC2206
     var_val=(${env_var//=/ })
     container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "$var_val[0]" --arg ENVVAL "$var_val[1]" \
-      ".[${image_idx}].environment += {'name': \$ENVVAR, value: \$ENVVAL}"
+      ".[${image_idx}].environment += {'name': \$ENVVAR, 'value': \$ENVVAL}"
     )
   done
   image_idx=$((image_idx+1))

--- a/plugin.yml
+++ b/plugin.yml
@@ -8,6 +8,8 @@ configuration:
   properties:
     cluster:
       type: string
+    container-definitions:
+      type: string
     service:
       type: string
     task-definition:
@@ -37,6 +39,6 @@ configuration:
   required:
     - cluster
     - service
-    - task-definition
+    - container-definitions
     - task-family
     - image

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,8 @@ configuration:
       type: string
     task-family:
       type: string
+    service-definition:
+      type: string
     image:
       type: [ string, array ]
     desired-count:

--- a/plugin.yml
+++ b/plugin.yml
@@ -32,8 +32,8 @@ configuration:
       type: string
     deployment-config:
       type: string
-    env-file-url:
-      type: string
+    env:
+      type: array
   required:
     - cluster
     - service

--- a/plugin.yml
+++ b/plugin.yml
@@ -32,6 +32,8 @@ configuration:
       type: string
     deployment-config:
       type: string
+    env-file-url:
+      type: string
   required:
     - cluster
     - service

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -23,7 +23,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
 
   stub aws \
     "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
@@ -41,7 +41,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
 }
 
@@ -52,7 +52,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_0=hello-world:llamas
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_1=hello-world:alpacas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/multiple-images.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/multiple-images.json
 
   expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  },\n  {\n    "essential": true,\n    "image": "hello-world:alpacas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
 
@@ -72,7 +72,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_0
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_1
 }
@@ -83,7 +83,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
 
   stub aws \
     "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
@@ -102,9 +102,9 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
 }
 
 @test "Run a deploy with task role" {
@@ -113,7 +113,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN=arn:aws:iam::012345678910:role/world
 
   stub aws \
@@ -132,7 +132,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN
 }
@@ -143,7 +143,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP=arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME=nginx
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
@@ -167,7 +167,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT
@@ -179,7 +179,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME=nginx-elb
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME=nginx
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
@@ -201,7 +201,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME
@@ -213,7 +213,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE=arn:aws:iam::012345678910:role/world
 
   stub aws \
@@ -232,7 +232,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE
 }
@@ -243,7 +243,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION="0/100"
 
   stub aws \
@@ -263,7 +263,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION
 }
@@ -274,7 +274,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=tests/incorrect-container-definition.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=tests/incorrect-container-definition.json
 
   run "$PWD/hooks/command"
   assert_failure
@@ -282,7 +282,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
 
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
   unset BUILDKITE_BUILD_NUMBER
 }


### PR DESCRIPTION
In order to enable Fargate support, as well as provide greater configurability, this PR does two things:

1) rename the `task-definition` parameter to `container-definitions` - This is actually the correct name for the json file in question. I hesitated to do this because it's a *breaking change*, however it seemed preferable to conform to AWS's naming convention

2) added support for a true `task-definition` parameter: this file gets passed as an argument to `register-task-definition --cli-input-json`. This is safe as a pure addition because the aws cli overrides values in this json with explicitly passed parameters, so things like `task-role-arn` can still be overridden in the plugin settings

3) added support for a `service-definition` parameter. Used for creating the service, behaves the same way as `task-definition`

By doing this we enable fargate configuration in a generic way without an explosion of parameters. This PR includes commits from #62 which should be reviewed and merged first. ~However, I should note that this still does not fully enable fargate (#34) due to the lack of support for network configuration in the `create-service` step. If this PR is not merged before then I will update it with the proper support.~