### PR TITLE
Support for task environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Example: `"0/100"`
 
 The region we deploy the ECS Service to.
 
+### `env` (optional)
+
+An array of environment variables to add to *every* image's task definition
+
 ## AWS Roles
 
 At a minimum this plugin requires the following AWS permissions to be granted to the agent running this step:

--- a/hooks/command
+++ b/hooks/command
@@ -40,6 +40,7 @@ target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
 target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
 execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
 region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
+env_file_url=${BUILDKITE_PLUGIN_ECS_DEPLOY_ENV_FILE_URL:-""}
 
 if [[ $region != "" ]]; then
   # shellcheck disable=SC2034 # Used by the aws cli
@@ -118,6 +119,9 @@ for image in "${images[@]}"; do
   )
   image_idx=$((image_idx+1))
 done
+
+echo "--- :thisisfine: "
+echo "$container_definitions_json"
 
 echo "--- :ecs: Registering new task definition for ${task_family}"
 register_command="aws ecs register-task-definition \

--- a/hooks/command
+++ b/hooks/command
@@ -126,14 +126,13 @@ done
 ## This adds the env vars to each container
 echo "--- :thisisfine: attempting env var load"
 image_idx=0
-container_definitions_json=$(cat "${task_definition}")
 for image in "${images[@]}"; do
   container_definitions_json=$(echo "$container_definitions_json" | jq ".[${image_idx}].environment=[]"
   )
   for env_var in "${env_vars[@]}"; do
     # shellcheck disable=SC2206
     var_val=(${env_var//=/ })
-    container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "$var_val[0]" --arg ENVVAL "$var_val[1]" \
+    container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "${var_val[0]}" --arg ENVVAL "${var_val[1]}" \
       ".[${image_idx}].environment += [{\"name\": \$ENVVAR, \"value\": \$ENVVAL}]"
     )
   done

--- a/hooks/command
+++ b/hooks/command
@@ -126,8 +126,6 @@ done
 ## This adds the env vars to each container
 image_idx=0
 for image in "${images[@]}"; do
-  container_definitions_json=$(echo "$container_definitions_json" | jq ".[${image_idx}].environment=[]"
-  )
   for env_var in "${env_vars[@]}"; do
     # shellcheck disable=SC2206
     var_val=(${env_var//=/ })

--- a/hooks/command
+++ b/hooks/command
@@ -134,7 +134,7 @@ for image in "${images[@]}"; do
     # shellcheck disable=SC2206
     var_val=(${env_var//=/ })
     container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "$var_val[0]" --arg ENVVAL "$var_val[1]" \
-      '.[${image_idx}].environment += {"name": \$ENVVAR, "value": \$ENVVAL}'
+      ".[${image_idx}].environment += [{\"name\": \$ENVVAR, \"value\": \$ENVVAL}]"
     )
   done
   image_idx=$((image_idx+1))

--- a/hooks/command
+++ b/hooks/command
@@ -124,6 +124,7 @@ for image in "${images[@]}"; do
 done
 
 ## This adds the env vars to each container
+echo "--- :thisisfine: attempting env var load"
 image_idx=0
 container_definitions_json=$(cat "${task_definition}")
 for image in "${images[@]}"; do

--- a/hooks/command
+++ b/hooks/command
@@ -124,7 +124,6 @@ for image in "${images[@]}"; do
 done
 
 ## This adds the env vars to each container
-echo "--- :thisisfine: attempting env var load"
 image_idx=0
 for image in "${images[@]}"; do
   container_definitions_json=$(echo "$container_definitions_json" | jq ".[${image_idx}].environment=[]"
@@ -138,9 +137,6 @@ for image in "${images[@]}"; do
   done
   image_idx=$((image_idx+1))
 done
-
-echo "--- :thisisfine: "
-echo "$container_definitions_json"
 
 echo "--- :ecs: Registering new task definition for ${task_family}"
 register_command="aws ecs register-task-definition \

--- a/hooks/command
+++ b/hooks/command
@@ -40,7 +40,10 @@ target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
 target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
 execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
 region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
-env_file_url=${BUILDKITE_PLUGIN_ECS_DEPLOY_ENV_FILE_URL:-""}
+env_vars=()
+while read -r line ; do
+  [[ -n "$line" ]] && images+=("$line")
+done <<< "$(plugin_read_list ENV)"
 
 if [[ $region != "" ]]; then
   # shellcheck disable=SC2034 # Used by the aws cli
@@ -117,6 +120,22 @@ for image in "${images[@]}"; do
   container_definitions_json=$(echo "$container_definitions_json" | jq --arg IMAGE "$image" \
   ".[${image_idx}].image=\$IMAGE"
   )
+  image_idx=$((image_idx+1))
+done
+
+## This adds the env vars to each container
+image_idx=0
+container_definitions_json=$(cat "${task_definition}")
+for image in "${images[@]}"; do
+  container_definitions_json=$(echo "$container_definitions_json" | jq ".[${image_idx}].environment=[]"
+  )
+  for env_var in "${env_vars[@]}"; do
+    # shellcheck disable=SC2206
+    var_val=(${env_var//=/ })
+    container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "$var_val[0]" --arg ENVVAL "$var_val[1]" \
+      ".[${image_idx}].environment += {'name': \$ENVVAR, value: \$ENVVAL}"
+    )
+  done
   image_idx=$((image_idx+1))
 done
 

--- a/hooks/command
+++ b/hooks/command
@@ -134,7 +134,7 @@ for image in "${images[@]}"; do
     # shellcheck disable=SC2206
     var_val=(${env_var//=/ })
     container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "$var_val[0]" --arg ENVVAL "$var_val[1]" \
-      ".[${image_idx}].environment += {'name': \$ENVVAR, 'value': \$ENVVAL}"
+      '.[${image_idx}].environment += {"name": \$ENVVAR, "value": \$ENVVAL}'
     )
   done
   image_idx=$((image_idx+1))

--- a/hooks/command
+++ b/hooks/command
@@ -42,7 +42,7 @@ execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
 region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
 env_vars=()
 while read -r line ; do
-  [[ -n "$line" ]] && images+=("$line")
+  [[ -n "$line" ]] && env_vars+=("$line")
 done <<< "$(plugin_read_list ENV)"
 
 if [[ $region != "" ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -134,7 +134,7 @@ for image in "${images[@]}"; do
     # shellcheck disable=SC2206
     var_val=(${env_var//=/ })
     container_definitions_json=$(echo "$container_definitions_json" | jq --arg ENVVAR "$var_val[0]" --arg ENVVAL "$var_val[1]" \
-      ".[${image_idx}].environment += {'name': \$ENVVAR, value: \$ENVVAL}"
+      ".[${image_idx}].environment += {'name': \$ENVVAR, 'value': \$ENVVAL}"
     )
   done
   image_idx=$((image_idx+1))

--- a/plugin.yml
+++ b/plugin.yml
@@ -32,8 +32,8 @@ configuration:
       type: string
     deployment-config:
       type: string
-    env-file-url:
-      type: string
+    env:
+      type: array
   required:
     - cluster
     - service

--- a/plugin.yml
+++ b/plugin.yml
@@ -32,6 +32,8 @@ configuration:
       type: string
     deployment-config:
       type: string
+    env-file-url:
+      type: string
   required:
     - cluster
     - service

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -52,6 +52,9 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_0=hello-world:llamas
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_1=hello-world:alpacas
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_ENV_0="FOO=bar"
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_ENV_1="BAZ=bing"
+
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/multiple-images.json
 
   expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  },\n  {\n    "essential": true,\n    "image": "hello-world:alpacas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'


### PR DESCRIPTION
This is the same as #62, but rebased off the latest changes

## Original PR description (by @aleksclark)

This update adds support for adding build-time env vars to the container task definition. Our use case is per-branch staging environments, where we need to set things like external hostnames in the container, based on the branch name being built.