### PR TITLE
Container/Task/Service definitions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":docker: :hammer:"
     plugins:
-      docker-compose#v3.9.0:
+      docker-compose#v3.10.0:
         run: tests
 
   - label: ":shell: Lint"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ steps:
       - ecs-deploy#v1.4.1:
           cluster: "my-ecs-cluster"
           service: "my-service"
-          task-definition: "examples/hello-world.json"
+          container-definitions: "examples/hello-world.json"
           task-family: "hello-world"
           image: "${ECR_REPOSITORY}/hello-world:${BUILDKITE_BUILD_NUMBER}"
 ```
@@ -37,11 +37,50 @@ The name of the ECS service.
 
 Example: `"my-service"`
 
+### `container-definitions`
+
+The file path to the ECS container definition JSON file. This JSON file must be an array of objects, each corresponding to one of the images you defined in the `image` parameter.
+
+Example: `"ecs/containers.json"`
+```json
+[
+    {
+        "essential": true,
+        "image": "amazon/amazon-ecs-sample",
+        "memory": 100,
+        "name": "sample",
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 80
+            }
+        ]
+    },
+    {
+        "essential": true,
+        "image": "amazon/amazon-ecs-sample",
+        "memory": 100,
+        "name": "sample",
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 80
+            }
+        ]
+    }
+]
+```
+
 ### `task-definition`
 
-The file path to the ECS task definition JSON file.
+The file path to the ECS task definition JSON file. Parameters specified in this file will be overridden by other arguments if set. Setting the `containers` property in this file will have no effect, define those parameters in `container-definitions`
 
 Example: `"ecs/task.json"`
+```json
+{
+  "networkMode": "awsvpc"
+}
+```
 
 ### `task-family`
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ Example: `"ecs/task.json"`
 }
 ```
 
+### `service-definition`
+
+The file path to the ECS service definition JSON file. Parameters specified in this file will be overridden by other arguments if set, e.g. `cluster`, `desired-count`, etc. Note that currently this json input will only be used when creating the service, NOT when updating it.
+
+Example: `"ecs/service.json"`
+```json
+{
+  "schedulingStrategy": "DAEMON",
+  "propagateTags": "TASK_DEFINITION"
+}
+```
+
 ### `task-family`
 
 The name of the task family.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
   tests:
-    image: buildkite/plugin-tester:v3.0.0
+    image: buildkite/plugin-tester:v3.0.1
     volumes:
       - ".:/plugin:ro"

--- a/examples/service-definition.json
+++ b/examples/service-definition.json
@@ -1,0 +1,4 @@
+{
+    "schedulingStrategy": "DAEMON",
+    "propagateTags": "TASK_DEFINITION"
+}

--- a/examples/task-definition.json
+++ b/examples/task-definition.json
@@ -1,0 +1,3 @@
+{
+    "networkMode": "awsvpc"
+}

--- a/hooks/command
+++ b/hooks/command
@@ -31,7 +31,7 @@ images=()
 while read -r line ; do
   [[ -n "$line" ]] && images+=("$line")
 done <<< "$(plugin_read_list IMAGE)"
-task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION?}
+task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION:-""}
 container_definitions=${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS?}
 desired_count=${BUILDKITE_PLUGIN_ECS_DEPLOY_DESIRED_COUNT:-"1"}
 task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-""}

--- a/hooks/command
+++ b/hooks/command
@@ -32,6 +32,7 @@ while read -r line ; do
   [[ -n "$line" ]] && images+=("$line")
 done <<< "$(plugin_read_list IMAGE)"
 task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION?}
+container_definitions=${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS?}
 desired_count=${BUILDKITE_PLUGIN_ECS_DEPLOY_DESIRED_COUNT:-"1"}
 task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-""}
 target_group=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP:-""}
@@ -60,9 +61,9 @@ min_max_percent=(${deployment_config//\// })
 min_deploy_perc=${min_max_percent[0]}
 max_deploy_perc=${min_max_percent[1]}
 
-if [[ $(jq '. | keys |first' "$task_definition") != "0" ]]; then
+if [[ $(jq '. | keys |first' "$container_definitions") != "0" ]]; then
     echo "^^^"
-    echo "Invalid Task Definition"
+    echo "Invalid Container Definitions"
     echo 'JSON definition should be in the format of [{"image": "..."}]'
     exit 1
 fi
@@ -115,7 +116,7 @@ function generate_target_group_arguments() {
 
 ## This is the template definition of your containers
 image_idx=0
-container_definitions_json=$(cat "${task_definition}")
+container_definitions_json=$(cat "${container_definitions}")
 for image in "${images[@]}"; do
   container_definitions_json=$(echo "$container_definitions_json" | jq --arg IMAGE "$image" \
   ".[${image_idx}].image=\$IMAGE"
@@ -148,6 +149,14 @@ fi
 if [[ -n "${execution_role}" ]]; then
     register_command+=" --execution-role-arn ${execution_role}"
 fi
+
+if [[ -n "${task_definition}" ]]; then
+    task_definition_json=$(cat "${task_definition}")
+    register_command+=" --cli-input-json '$task_definition_json'"
+fi
+
+echo "--- :ecs: register command:"
+echo $register_command
 
 json_output=$(eval "$register_command")
 register_exit_code=$?

--- a/hooks/command
+++ b/hooks/command
@@ -32,6 +32,7 @@ while read -r line ; do
   [[ -n "$line" ]] && images+=("$line")
 done <<< "$(plugin_read_list IMAGE)"
 task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION:-""}
+service_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE_DEFINITION:-""}
 container_definitions=${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS?}
 desired_count=${BUILDKITE_PLUGIN_ECS_DEPLOY_DESIRED_COUNT:-"1"}
 task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-""}
@@ -75,6 +76,11 @@ function create_service() {
     local desired_count=$4
     local target_group_arguments
     target_group_arguments=$(generate_target_group_arguments "$5" "$6" "$7")
+    
+    local service_definition_json="{}"
+    if [[ -n "${service_definition}" ]]; then
+      service_definition_json=$(cat "${service_definition}")
+    fi
 
     # shellcheck disable=SC2016
     service_defined=$(aws ecs describe-services --cluster "$cluster_name" --service "$service_name" --query 'services[?status==`ACTIVE`].status' --output text |wc -l)
@@ -87,7 +93,8 @@ function create_service() {
         --task-definition "$task_definition" \
         --desired-count "$desired_count" \
         --deployment-configuration "maximumPercent=${max_deploy_perc},minimumHealthyPercent=${min_deploy_perc}" \
-        $target_group_arguments
+        $target_group_arguments \
+        --cli-input-json service_definition_json
     fi
 }
 
@@ -152,11 +159,10 @@ fi
 
 if [[ -n "${task_definition}" ]]; then
     task_definition_json=$(cat "${task_definition}")
-    register_command+=" --cli-input-json '$task_definition_json'"
+    register_command+=" --cli-input-json '${task_definition_json}'"
 fi
 
 echo "--- :ecs: register command:"
-echo $register_command
 
 json_output=$(eval "$register_command")
 register_exit_code=$?

--- a/hooks/command
+++ b/hooks/command
@@ -94,7 +94,7 @@ function create_service() {
         --desired-count "$desired_count" \
         --deployment-configuration "maximumPercent=${max_deploy_perc},minimumHealthyPercent=${min_deploy_perc}" \
         $target_group_arguments \
-        --cli-input-json service_definition_json
+        --cli-input-json "$service_definition_json"
     fi
 }
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -8,6 +8,8 @@ configuration:
   properties:
     cluster:
       type: string
+    container-definitions:
+      type: string
     service:
       type: string
     task-definition:
@@ -37,6 +39,6 @@ configuration:
   required:
     - cluster
     - service
-    - task-definition
+    - container-definitions
     - task-family
     - image

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,8 @@ configuration:
       type: string
     task-family:
       type: string
+    service-definition:
+      type: string
     image:
       type: [ string, array ]
     desired-count:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -56,7 +56,7 @@ expected_task_definition='{\n    "networkMode": "awsvpc"\n}'
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/task-definition.json
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' --cli-input-json '\'$expected_task_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' --cli-input-json $'$expected_task_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -118,13 +118,16 @@ expected_service_definition='{\n    "schedulingStrategy": "DAEMON",\n    "propag
   export BUILDKITE_PLUGIN_ECS_DEPLOY_ENV_0="FOO=bar"
   export BUILDKITE_PLUGIN_ECS_DEPLOY_ENV_1="BAZ=bing"
 
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/multiple-images.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/multiple-images.json
 
-  # first command stubbed saves the container definition to ${_TMP_DIR}/container_definition for later review and manipulation
+  # first command stubbed saves the container definition to ${TMP_DIR}/container_definition for later review and manipulation
+  # we should be stubbing a lot more calls, but we don't care about those so let the stubbing fail
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions '*' : echo \"\$6\" > ${_TMP_DIR}/container_definition ; echo '{\"taskDefinition\":{\"revision\":1}}'"
+    "ecs register-task-definition --family hello-world --container-definitions \* : echo \"\$6\" > ${_TMP_DIR}/container_definition ; echo '{\"taskDefinition\":{\"revision\":1}}'"
 
   run "$PWD/hooks/command"
+
+  assert_success
 
   # there is no assert_success because we are just checking that the definition was updated accordingly
   assert_equal $(cat ${_TMP_DIR}/container_definition | jq -r '.[0].environment[0].name') 'FOO'

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -23,7 +23,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
 
   stub aws \
     "ecs register-task-definition --family hello-world --container-definitions $'${expected_container_definition}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
@@ -41,7 +41,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
 }
 
@@ -52,8 +52,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_0=hello-world:llamas
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_1=hello-world:alpacas
-
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/multiple-images.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/multiple-images.json
 
   expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  },\n  {\n    "essential": true,\n    "image": "hello-world:alpacas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
 
@@ -73,7 +72,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_0
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_1
 }
@@ -123,7 +122,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
 
   stub aws \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
@@ -142,9 +141,9 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
 }
 
 @test "Run a deploy with task role" {
@@ -153,7 +152,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN=arn:aws:iam::012345678910:role/world
 
   stub aws \
@@ -172,7 +171,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN
 }
@@ -183,7 +182,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP=arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME=nginx
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
@@ -207,7 +206,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT
@@ -219,7 +218,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME=nginx-elb
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME=nginx
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
@@ -241,7 +240,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME
@@ -253,7 +252,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE=arn:aws:iam::012345678910:role/world
 
   stub aws \
@@ -272,7 +271,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE
 }
@@ -283,7 +282,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION="0/100"
 
   stub aws \
@@ -303,7 +302,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   unstub aws
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION
 }
@@ -314,7 +313,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=tests/incorrect-container-definition.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=tests/incorrect-container-definition.json
 
   run "$PWD/hooks/command"
   assert_failure
@@ -322,7 +321,7 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
 
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
   unset BUILDKITE_BUILD_NUMBER
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -16,6 +16,7 @@ setup() {
 # export AWS_STUB_DEBUG=/dev/tty
 
 expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
+expected_task_definition='{\n    "networkMode": "awsvpc"\n}'
 
 @test "Run a deploy when service exists" {
   export BUILDKITE_BUILD_NUMBER=1
@@ -27,6 +28,35 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
 
   stub aws \
     "ecs register-task-definition --family hello-world --container-definitions $'${expected_container_definition}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
+    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
+    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
+    "ecs describe-services --cluster my-cluster --service my-service : echo ok"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "Service is up 🚀"
+
+  unstub aws
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
+}
+
+@test "Run a deploy with a task definition json file" {
+  export BUILDKITE_BUILD_NUMBER=1
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/task-definition.json
+
+  stub aws \
+    "ecs register-task-definition --family hello-world --container-definitions '\'$expected_container_definition\'' --cli-input-json '\'$expected_task_definition\'' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\`ACTIVE\`].status' --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\`ACTIVE\`]' : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \


### PR DESCRIPTION
This is the same as PR #64 but cherry-picked on top of the most invasive changes already done in the repository.

**Important: this is a backwards-incompatible change**

## Original PR description (by @aleksclark)

In order to enable Fargate support, as well as provide greater configurability, this PR does two things:

1) rename the `task-definition` parameter to `container-definitions` - This is actually the correct name for the json file in question. I hesitated to do this because it's a *breaking change*, however it seemed preferable to conform to AWS's naming convention

2) added support for a true `task-definition` parameter: this file gets passed as an argument to `register-task-definition --cli-input-json`. This is safe as a pure addition because the aws cli overrides values in this json with explicitly passed parameters, so things like `task-role-arn` can still be overridden in the plugin settings

3) added support for a `service-definition` parameter. Used for creating the service, behaves the same way as `task-definition`

By doing this we enable fargate configuration in a generic way without an explosion of parameters. This PR includes commits from #62 which should be reviewed and merged first. ~However, I should note that this still does not fully enable fargate (#34) due to the lack of support for network configuration in the `create-service` step. If this PR is not merged before then I will update it with the proper support.~