### PR TITLE
Fix jmes query quotes (preventing updating existing service)

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -70,7 +70,7 @@ function create_service() {
         "${aws_default_args[@]}" \
         --cluster "$cluster_name" \
         --service "$service_name" \
-        --query 'services[?status=="ACTIVE"].status' \
+        --query "services[?status=='ACTIVE'].status" \
         --output text \
         | wc -l
     )
@@ -180,7 +180,7 @@ echo "Registered ${task_family}:${task_revision}"
 # Create service if it doesn't already exist
 create_service "$cluster" "${task_family}:${task_revision}" "$service_name" "$desired_count" "$target_group" "$target_container" "$target_port"
 
-lb_config=$(aws ecs describe-services --cluster "$cluster" --services "$service_name" --query 'services[?status=="ACTIVE"]' | jq -r '.[0].loadBalancers[0]')
+lb_config=$(aws ecs describe-services --cluster "$cluster" --services "$service_name" --query "services[?status=='ACTIVE']" | jq -r '.[0].loadBalancers[0]')
 error="+++ ^^^
 +++ Cannot update a service to add/remove a load balancer. First delete the service and then run again, or rename the service to force a new one to be created"
 


### PR DESCRIPTION
This plugin was always trying to create a new service for me, even when one existing. I traced it through and found that the type of quotes in these queries matters:

```
 aws ecs describe-services --cluster buildkite-ecs-oidc-example --service buildkite-ecs-oidc-example --query 'services[?status == "ACTIVE"].status'
[]
```

```
aws ecs describe-services --cluster buildkite-ecs-oidc-example --service buildkite-ecs-oidc-example --query "services[?status == 'ACTIVE'].status"
[
    "ACTIVE"
]
```

I have aws-cli 2, not sure if that's relevant:

```
aws-cli/2.9.21 Python/3.11.1 Darwin/21.6.0 source/arm64 prompt/off
```