### PR TITLE
Use existing container definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,15 @@ steps:
 
 ## Options
 
-### `cluster`
+### Required
+
+#### `cluster`
 
 The name of the ECS cluster.
 
 Example: `"my-cluster"`
 
-### `service`
-
-The name of the ECS service.
-
-Example: `"my-service"`
-
-### `container-definitions`
+#### `container-definitions`
 
 The file path to the ECS container definition JSON file. This JSON file must be an array of objects, each corresponding to one of the images you defined in the `image` parameter.
 
@@ -71,36 +67,7 @@ Example: `"ecs/containers.json"`
 ]
 ```
 
-### `task-definition`
-
-The file path to the ECS task definition JSON file. Parameters specified in this file will be overridden by other arguments if set. Setting the `containers` property in this file will have no effect, define those parameters in `container-definitions`
-
-Example: `"ecs/task.json"`
-```json
-{
-  "networkMode": "awsvpc"
-}
-```
-
-### `service-definition`
-
-The file path to the ECS service definition JSON file. Parameters specified in this file will be overridden by other arguments if set, e.g. `cluster`, `desired-count`, etc. Note that currently this json input will only be used when creating the service, NOT when updating it.
-
-Example: `"ecs/service.json"`
-```json
-{
-  "schedulingStrategy": "DAEMON",
-  "propagateTags": "TASK_DEFINITION"
-}
-```
-
-### `task-family`
-
-The name of the task family.
-
-Example: `"my-task"`
-
-### `image`
+#### `image`
 
 The Docker image to deploy. This can be an array to substitute multiple images in a single container definition.
 
@@ -113,26 +80,31 @@ image:
   - "012345.dkr.ecr.us-east-1.amazonaws.com/nginx:123"
 ```
 
-### `task-role-arn` (optional)
+#### `service`
 
-An IAM ECS Task Role to assign to tasks.
-Requires the `iam:PassRole` permission for the ARN specified.
+The name of the ECS service.
 
-### `target-group` (optional)
+Example: `"my-service"`
 
-The Target Group ARN to map the service to.
+#### `task-family`
 
-Example: `"arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc"`
+The name of the task family.
 
-### `target-container-name` (optional)
+Example: `"my-task"`
 
-The Container Name to forward ALB requests to.
+### Optional
 
-### `target-container-port` (optional)
+#### `deployment-configuration` (optional)
 
-The Container Port to forward requests to.
+The minimum and maximum percentage of tasks that should be maintained during a deployment. Defaults to `100/200`
 
-### `execution-role` (optional)
+Example: `"0/100"`
+
+#### `env` (optional)
+
+An array of environment variables to add to *every* image's task definition
+
+#### `execution-role` (optional)
 
 The Execution Role ARN used by ECS to pull container images and secrets.
 
@@ -140,19 +112,51 @@ Example: `"arn:aws:iam::012345678910:role/execution-role"`
 
 Requires the `iam:PassRole` permission for the execution role.
 
-### `deployment-configuration` (optional)
-
-The minimum and maximum percentage of tasks that should be maintained during a deployment. Defaults to `100/200`
-
-Example: `"0/100"`
-
-### `region` (optional)
+#### `region` (optional)
 
 The region we deploy the ECS Service to.
 
-### `env` (optional)
+#### `service-definition`
 
-An array of environment variables to add to *every* image's task definition
+The file path to the ECS service definition JSON file. Parameters specified in this file will be overridden by other arguments if set, e.g. `cluster`, `desired-count`, etc. Note that currently this json input will only be used when creating the service, NOT when updating it.
+
+Example: `"ecs/service.json"`
+```json
+{
+  "schedulingStrategy": "DAEMON",
+  "propagateTags": "TASK_DEFINITION"
+}
+```
+
+#### `target-group` (optional)
+
+The Target Group ARN to map the service to.
+
+Example: `"arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc"`
+
+#### `target-container-name` (optional)
+
+The Container Name to forward ALB requests to.
+
+#### `target-container-port` (optional)
+
+The Container Port to forward requests to.
+
+##### `task-definition`
+
+The file path to the ECS task definition JSON file. Parameters specified in this file will be overridden by other arguments if set. Setting the `containers` property in this file will have no effect, define those parameters in `container-definitions`
+
+Example: `"ecs/task.json"`
+```json
+{
+  "networkMode": "awsvpc"
+}
+```
+
+#### `task-role-arn` (optional)
+
+An IAM ECS Task Role to assign to tasks.
+Requires the `iam:PassRole` permission for the ARN specified.
 
 ## AWS Roles
 

--- a/README.md
+++ b/README.md
@@ -130,12 +130,6 @@ Example: `"ecs/service.json"`
 }
 ```
 
-#### `target-group` (optional)
-
-The Target Group ARN to map the service to.
-
-Example: `"arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc"`
-
 #### `target-container-name` (optional)
 
 The Container Name to forward ALB requests to.
@@ -143,6 +137,36 @@ The Container Name to forward ALB requests to.
 #### `target-container-port` (optional)
 
 The Container Port to forward requests to.
+
+#### `target-group` (optional)
+
+The Target Group ARN to map the service to.
+
+Example: `"arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc"`
+
+#### `task-cpu` (optional, integer)
+
+CPU Units to assign to the task (1024 constitutes a whole CPU). Example: `256` (1/4 of a CPU).
+
+#### `task-ephemeral-storage` (optional, integer)
+
+Amount of GBs to assign in ephemeral storage to the task. Example: `25`.
+
+#### `task-ipc-mode` (optional)
+
+IPC resource namespace to use in the task. If specified, should be one of `host`, `task` or `none`.
+
+#### `task-memory` (optional, integer)
+
+Amount of memory (in Mbs) to allocate for the task. Example: `1024` (1Gb).
+
+#### `task-network-mode` (optional)
+
+Docker networking mode for the containers running in the task. If specified, should be one of `bridge`, `host`, `awsvpc` or `none`.
+
+#### `task-pid-mode` (optional)
+
+Process namespace to use for containers in the task. If specified, should be one of `host` or `task`.
 
 #### `task-role-arn` (optional)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) for deploying to [Amazon ECS](https://aws.amazon.com/ecs/).
 
-* Requires the aws cli tool be installed
+* Requires both `aws` and `jq` cli tools to be installed
 * Registers a new task definition based on a given JSON file ([`register-task-definition`](http://docs.aws.amazon.com/cli/latest/reference/ecs/register-task-definition.html))
 * Updates the ECS service to use the new task definition ([`update-service`](http://docs.aws.amazon.com/cli/latest/reference/ecs/update-service.html))
 * Waits for the service to stabilize ([`wait services-stable`](http://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html))
@@ -15,7 +15,7 @@ steps:
     concurrency_group: "my-service-deploy"
     concurrency: 1
     plugins:
-      - ecs-deploy#v2.0.1:
+      - ecs-deploy#v2.1.0:
           cluster: "my-ecs-cluster"
           service: "my-service"
           container-definitions: "examples/hello-world.json"
@@ -34,6 +34,8 @@ The name of the ECS cluster.
 Example: `"my-cluster"`
 
 #### `container-definitions`
+
+_Experimental:_ Since version 2.1.0 you can skip this parameter and the container definitions will be obtained off the existing (latest) task definition. If this does not work for you, please open an issue in this repository.
 
 The file path to the ECS container definition JSON file. This JSON file must be an array of objects, each corresponding to one of the images you defined in the `image` parameter.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Example: `"my-cluster"`
 
 #### `container-definitions`
 
-_Experimental:_ Since version 2.1.0 you can skip this parameter and the container definitions will be obtained off the existing (latest) task definition. If this does not work for you, please open an issue in this repository.
+_Experimental:_ Since version 3.0.0 you can skip this parameter and the container definitions will be obtained off the existing (latest) task definition. If this does not work for you, please open an issue in this repository.
 
 The file path to the ECS container definition JSON file. This JSON file must be an array of objects, each corresponding to one of the images you defined in the `image` parameter.
 
@@ -143,17 +143,6 @@ The Container Name to forward ALB requests to.
 #### `target-container-port` (optional)
 
 The Container Port to forward requests to.
-
-##### `task-definition`
-
-The file path to the ECS task definition JSON file. Parameters specified in this file will be overridden by other arguments if set. Setting the `containers` property in this file will have no effect, define those parameters in `container-definitions`
-
-Example: `"ecs/task.json"`
-```json
-{
-  "networkMode": "awsvpc"
-}
-```
 
 #### `task-role-arn` (optional)
 

--- a/examples/described-task-full.json
+++ b/examples/described-task-full.json
@@ -1,5 +1,6 @@
 {
   "taskDefinitionArn": "TaskARN",
+  "taskRoleArn": "RoleARN",
   "containerDefinitions": [
     {
       "essential": true,
@@ -15,10 +16,15 @@
     }
   ],
   "family": "hello-world",
+  "executionRoleArn": "ExecutionRoleARN",
+  "networkMode": "awsvpc",
   "revision": 1,
+  "volumes": [],
   "status": "ACTIVE",
   "compatibilities": [
     "EC2",
     "FARGATE"
-  ]
+  ],
+  "cpu": "10",
+  "memory": "100"
 }

--- a/examples/described-task-multiple.json
+++ b/examples/described-task-multiple.json
@@ -1,0 +1,41 @@
+{
+  "taskDefinitionArn": "TaskARN",
+  "containerDefinitions": [
+    {
+      "essential": true,
+      "image": "amazon/amazon-ecs-sample",
+      "memory": 100,
+      "name": "sample",
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 80
+        }
+      ]
+    },
+    {
+      "essential": true,
+      "image": "amazon/amazon-ecs-sample",
+      "memory": 100,
+      "name": "sample",
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 80
+        }
+      ]
+    }
+  ],
+  "family": "hello-world",
+  "executionRoleArn": "ExecutionRoleARN",
+  "networkMode": "awsvpc",
+  "revision": 1,
+  "volumes": [],
+  "status": "ACTIVE",
+  "compatibilities": [
+    "EC2",
+    "FARGATE"
+  ],
+  "cpu": "10",
+  "memory": "100"
+}

--- a/examples/described-task-multiple.json
+++ b/examples/described-task-multiple.json
@@ -27,15 +27,10 @@
     }
   ],
   "family": "hello-world",
-  "executionRoleArn": "ExecutionRoleARN",
-  "networkMode": "awsvpc",
   "revision": 1,
-  "volumes": [],
   "status": "ACTIVE",
   "compatibilities": [
     "EC2",
     "FARGATE"
-  ],
-  "cpu": "10",
-  "memory": "100"
+  ]
 }

--- a/examples/described-task.json
+++ b/examples/described-task.json
@@ -1,0 +1,29 @@
+{
+  "taskDefinitionArn": "TaskARN",
+  "containerDefinitions": [
+    {
+      "essential": true,
+      "image": "amazon/amazon-ecs-sample",
+      "memory": 100,
+      "name": "sample",
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 80
+        }
+      ]
+    }
+  ],
+  "family": "hello-world",
+  "executionRoleArn": "ExecutionRoleARN",
+  "networkMode": "awsvpc",
+  "revision": 1,
+  "volumes": [],
+  "status": "ACTIVE",
+  "compatibilities": [
+    "EC2",
+    "FARGATE"
+  ],
+  "cpu": "10",
+  "memory": "100"
+}

--- a/examples/task-definition.json
+++ b/examples/task-definition.json
@@ -1,3 +1,0 @@
-{
-    "networkMode": "awsvpc"
-}

--- a/hooks/command
+++ b/hooks/command
@@ -96,58 +96,58 @@ register_command=(aws ecs register-task-definition
   --container-definitions "${container_definitions_json}"
 )
 
-execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-$(jq '.executionRoleArn // ""' "${task_file}")}
+execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-$(jq -r '.executionRoleArn // ""' "${task_file}")}
 if [ -n "${execution_role}" ]; then
   register_command+=(--execution-role-arn "${execution_role}")
 fi
 
-task_cpu=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_CPU:-$(jq '.cpu // ""' "${task_file}")}
+task_cpu=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_CPU:-$(jq -r '.cpu // ""' "${task_file}")}
 if [ -n "${task_cpu}" ]; then
   register_command+=(--cpu "${task_cpu}")
 fi
 
-task_ephemeral=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_EPHEMERAL_STORAGE:-$(jq '.cpu // ""' "${task_file}")}
+task_ephemeral=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_EPHEMERAL_STORAGE:-$(jq -r '.cpu // ""' "${task_file}")}
 if [ -n "${task_ephemeral}" ]; then
   register_command+=(--ephemeral-storage "sizeInGiB=${task_ephemeral}")
 fi
 
-task_ipc=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_IPC_MODE:-$(jq '.ipcMode // ""' "${task_file}")}
+task_ipc=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_IPC_MODE:-$(jq -r '.ipcMode // ""' "${task_file}")}
 if [ -n "${task_ipc}" ]; then
   register_command+=(--ipc-mode "${task_ipc}")
 fi
 
-task_memory=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_MEMORY:-$(jq '.memory // ""' "${task_file}")}
+task_memory=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_MEMORY:-$(jq -r '.memory // ""' "${task_file}")}
 if [ -n "${task_memory}" ]; then
   register_command+=(--memory "${task_memory}")
 fi
 
-task_network=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_NETWORK_MODE:-$(jq '.networkMode // ""' "${task_file}")}
+task_network=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_NETWORK_MODE:-$(jq -r '.networkMode // ""' "${task_file}")}
 if [ -n "${task_network}" ]; then
   register_command+=(--network-mode "${task_network}")
 fi
 
-task_pid=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_PID_MODE:-$(jq '.pidMode // ""' "${task_file}")}
+task_pid=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_PID_MODE:-$(jq -r '.pidMode // ""' "${task_file}")}
 if [ -n "${task_pid}" ]; then
   register_command+=(--pid-mode "${task_pid}")
 fi
 
-task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-$(jq '.taskRoleArn // ""' "${task_file}")}
+task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-$(jq -r '.taskRoleArn // ""' "${task_file}")}
 if [ -n "${task_role_arn}" ]; then
   register_command+=(--task-role-arn "${task_role_arn}")
 fi
 
 # Following options are to keep values (they are complex for plugin-based configurations)
-task_volumes=$(jq '.volumes // ""' "${task_file}")
+task_volumes=$(jq -r '.volumes // ""' "${task_file}")
 if [ -n "${task_volumes}" ]; then
   register_command+=(--volumes "${task_volumes}")
 fi
 
-task_placement=$(jq '.placementConstraints // ""' "${task_file}")
+task_placement=$(jq -r '.placementConstraints // ""' "${task_file}")
 if [ -n "${task_placement}" ]; then
   register_command+=(--placement-constraints "${task_placement}")
 fi
 
-task_compat_reqs=$(jq '.requiresCompatibilities // ""' "${task_file}")
+task_compat_reqs=$(jq -r '.requiresCompatibilities // ""' "${task_file}")
 if [ -n "${task_compat_reqs}" ]; then
   register_command+=(--requires-compatibilities "${task_compat_reqs}")
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -8,7 +8,6 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 # mandatory configurations
 cluster=${BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER?Missing cluster}
-container_definitions=${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS?Missing container definitions}
 task_family=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY?Missing task family}
 service_name=${BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE?Missing service name}
 
@@ -24,6 +23,25 @@ target_group=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP:-""}
 load_balancer_name=${BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME:-""}
 target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
 target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
+
+if [ -z "${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS:-}" ]; then
+  container_definitions=$(mktemp)
+  if ! aws ecs describe-task-definition --task-definition "${task_family}" --query 'taskDefinition.containerDefinitions' >"${container_definitions}"; then
+    echo ":boom: Could not get container definitions"
+    exit 1
+  fi
+  container_definitions_json=$(cat "${container_definitions}")
+  rm "${container_definitions}"
+else
+  container_definitions_json=$(cat "${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS}")
+fi
+
+if [[ $(jq '. | keys | first' <<<"$container_definitions_json") != "0" ]]; then
+    echo "^^^"
+    echo "Invalid Container Definitions"
+    echo 'JSON definition should be in the format of [{"image": "..."}]'
+    exit 1
+fi
 
 # necessary for compatibility with bash 4.3
 if plugin_read_list_into_result "ENV"; then
@@ -41,16 +59,8 @@ fi
 target_group=$(eval "echo $target_group")
 load_balancer_name=$(eval "echo $load_balancer_name")
 
-if [[ $(jq '. | keys | first' "$container_definitions") != "0" ]]; then
-    echo "^^^"
-    echo "Invalid Container Definitions"
-    echo 'JSON definition should be in the format of [{"image": "..."}]'
-    exit 1
-fi
-
 ## This is the template definition of your containers
 image_idx=0
-container_definitions_json=$(cat "${container_definitions}")
 for image in "${images[@]}"; do
   container_definitions_json=$(
     echo "$container_definitions_json" \

--- a/hooks/command
+++ b/hooks/command
@@ -91,19 +91,65 @@ done
 
 echo "--- :ecs: Registering new task definition for ${task_family}"
 register_command=(aws ecs register-task-definition
-    ${aws_default_args[@]+"${aws_default_args[@]}"}
-    --family "${task_family}"
-    --container-definitions "${container_definitions_json}"
+  ${aws_default_args[@]+"${aws_default_args[@]}"}
+  --family "${task_family}"
+  --container-definitions "${container_definitions_json}"
 )
 
-task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-""}
-if [[ -n "${task_role_arn}" ]]; then
-    register_command+=(--task-role-arn "${task_role_arn}")
+execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-$(jq '.executionRoleArn // ""' "${task_file}")}
+if [ -n "${execution_role}" ]; then
+  register_command+=(--execution-role-arn "${execution_role}")
 fi
 
-execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
-if [[ -n "${execution_role}" ]]; then
-    register_command+=(--execution-role-arn "${execution_role}")
+task_cpu=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_CPU:-$(jq '.cpu // ""' "${task_file}")}
+if [ -n "${task_cpu}" ]; then
+  register_command+=(--cpu "${task_cpu}")
+fi
+
+task_ephemeral=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_EPHEMERAL_STORAGE:-$(jq '.cpu // ""' "${task_file}")}
+if [ -n "${task_ephemeral}" ]; then
+  register_command+=(--ephemeral-storage "sizeInGiB=${task_ephemeral}")
+fi
+
+task_ipc=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_IPC_MODE:-$(jq '.ipcMode // ""' "${task_file}")}
+if [ -n "${task_ipc}" ]; then
+  register_command+=(--ipc-mode "${task_ipc}")
+fi
+
+task_memory=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_MEMORY:-$(jq '.memory // ""' "${task_file}")}
+if [ -n "${task_memory}" ]; then
+  register_command+=(--memory "${task_memory}")
+fi
+
+task_network=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_NETWORK_MODE:-$(jq '.networkMode // ""' "${task_file}")}
+if [ -n "${task_network}" ]; then
+  register_command+=(--network-mode "${task_network}")
+fi
+
+task_pid=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_PID_MODE:-$(jq '.pidMode // ""' "${task_file}")}
+if [ -n "${task_pid}" ]; then
+  register_command+=(--pid-mode "${task_pid}")
+fi
+
+task_role_arn=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN:-$(jq '.taskRoleArn // ""' "${task_file}")}
+if [ -n "${task_role_arn}" ]; then
+  register_command+=(--task-role-arn "${task_role_arn}")
+fi
+
+# Following options are to keep values (they are complex for plugin-based configurations)
+task_volumes=$(jq '.volumes // ""' "${task_file}")
+if [ -n "${task_volumes}" ]; then
+  register_command+=(--volumes "${task_volumes}")
+fi
+
+task_placement=$(jq '.placementConstraints // ""' "${task_file}")
+if [ -n "${task_placement}" ]; then
+  register_command+=(--placement-constraints "${task_placement}")
+fi
+
+task_compat_reqs=$(jq '.requiresCompatibilities // ""' "${task_file}")
+if [ -n "${task_compat_reqs}" ]; then
+  register_command+=(--requires-compatibilities "${task_compat_reqs}")
 fi
 
 echo "--- :ecs: register command:"

--- a/hooks/command
+++ b/hooks/command
@@ -33,9 +33,8 @@ else
 fi
 
 aws_default_args=()
-region=${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-""}
-if [[ -n "${region}" ]]; then
-  aws_default_args+=(--region "${region}")
+if [ -n "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-}" ]; then
+  aws_default_args+=(--region "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION}")
 fi
 
 # Resolve any runtime environment variables it has
@@ -48,76 +47,6 @@ if [[ $(jq '. | keys | first' "$container_definitions") != "0" ]]; then
     echo 'JSON definition should be in the format of [{"image": "..."}]'
     exit 1
 fi
-
-function create_service() {
-    local cluster_name=$1
-    local task_definition=$2
-    local service_name=$3
-    local desired_count=$4
-    local service_definition_json="{}"
-    local target_group_arguments
-
-    if generate_target_group_arguments "$5" "$6" "$7"; then
-      target_group_arguments=("${result[@]}")  # copying the array
-    else
-      target_group_arguments=()
-    fi
-
-    service_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE_DEFINITION:-""}
-    if [[ -n "${service_definition}" ]]; then
-      service_definition_json=$(cat "${service_definition}")
-    fi
-
-    service_defined=$(
-      aws ecs describe-services \
-        ${aws_default_args[@]+"${aws_default_args[@]}"} \
-        --cluster "$cluster_name" \
-        --service "$service_name" \
-        --query "services[?status=='ACTIVE'].status" \
-        --output text \
-        | wc -l
-    )
-    if [[ $service_defined -eq 0 ]]; then
-      echo "--- :ecs: Creating a Service $service_name in cluster $cluster_name"
-
-      deployment_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION:-"100/200"}
-      IFS="/" read -r -a min_max_percent <<< "${deployment_config}"
-      min_deploy_perc=${min_max_percent[0]}
-      max_deploy_perc=${min_max_percent[1]}
-
-      aws ecs create-service \
-        ${aws_default_args[@]+"${aws_default_args[@]}"} \
-        --cluster "$cluster_name" \
-        --service-name "$service_name" \
-        --task-definition "$task_definition" \
-        --desired-count "$desired_count" \
-        --deployment-configuration "maximumPercent=${max_deploy_perc},minimumHealthyPercent=${min_deploy_perc}" \
-        ${target_group_arguments[@]+"${target_group_arguments[@]}"} \
-        --cli-input-json "$service_definition_json"
-    fi
-}
-
-function generate_target_group_arguments() {
-    local target_group=$1
-    local target_container=$2
-    local target_port=$3
-    result=()
-    if [[ -n $target_container ]] && [[ -n $target_port ]]; then
-      local load_balancer_ref=""
-      if [[ -n $target_group ]]; then
-        load_balancer_ref="targetGroupArn=${target_group}"
-      elif [[ -n $load_balancer_name ]]; then
-        load_balancer_ref="loadBalancerName=${load_balancer_name}"
-      else
-        echo "+++ ^^^"
-        echo '+++ You must specify either target-group or load-balancer-name'
-        exit 1
-      fi
-
-      result+=(--load-balancers "${load_balancer_ref},containerName=${target_container},containerPort=${target_port}")
-    fi
-    return 0
-}
 
 ## This is the template definition of your containers
 image_idx=0
@@ -181,7 +110,63 @@ task_revision=$(jq '.taskDefinition.revision' <<< "$json_output")
 echo "Registered ${task_family}:${task_revision}"
 
 # Create service if it doesn't already exist
-create_service "$cluster" "${task_family}:${task_revision}" "$service_name" "$desired_count" "$target_group" "$target_container" "$target_port"
+aws_describe_service_args=(
+  --cluster "$cluster"
+  --service "$service_name"
+)
+
+aws_create_service_args=(
+  --cluster "$cluster"
+  --service-name "$service_name"
+  --task-definition "${task_family}:${task_revision}"
+  --desired-count "$desired_count"
+)
+
+service_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE_DEFINITION:-""}
+if [[ -n "${service_definition}" ]]; then
+  service_definition_json=$(cat "${service_definition}")
+else
+  service_definition_json="{}"
+fi
+
+service_defined=$(
+  aws ecs describe-services \
+    "${aws_default_args[@]+"${aws_default_args[@]}"}" \
+    "${aws_describe_service_args[@]}" \
+    --query 'services[?status=="ACTIVE"].status' \
+    --output text \
+    | wc -l
+)
+
+deployment_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION:-"100/200"}
+IFS="/" read -r -a min_max_percent <<< "${deployment_config}"
+min_deploy_perc=${min_max_percent[0]}
+max_deploy_perc=${min_max_percent[1]}
+
+aws_create_service_args+=(--deployment-configuration "maximumPercent=${max_deploy_perc},minimumHealthyPercent=${min_deploy_perc}")
+
+if [[ -n $target_container ]] && [[ -n $target_port ]]; then
+  if [[ -n $target_group ]]; then
+    load_balancer_ref="targetGroupArn=${target_group}"
+  elif [[ -n $load_balancer_name ]]; then
+    load_balancer_ref="loadBalancerName=${load_balancer_name}"
+  else
+    echo "+++ ^^^"
+    echo '+++ You must specify either target-group or load-balancer-name'
+    exit 1
+  fi
+
+  aws_create_service_args+=(--load-balancers "${load_balancer_ref},containerName=${target_container},containerPort=${target_port}")
+fi
+
+if [[ $service_defined -eq 0 ]]; then
+  echo "--- :ecs: Creating a Service $service_name in cluster $cluster"
+
+  aws ecs create-service \
+    "${aws_default_args[@]+"${aws_default_args[@]}"}" \
+    "${aws_create_service_args[@]}" \
+    --cli-input-json "$service_definition_json"
+fi
 
 lb_config=$(aws ecs describe-services --cluster "$cluster" --services "$service_name" --query "services[?status=='ACTIVE']" | jq -r '.[0].loadBalancers[0]')
 error="+++ ^^^

--- a/hooks/command
+++ b/hooks/command
@@ -106,7 +106,7 @@ if [ -n "${task_cpu}" ]; then
   register_command+=(--cpu "${task_cpu}")
 fi
 
-task_ephemeral=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_EPHEMERAL_STORAGE:-$(jq -r '.cpu // ""' "${task_file}")}
+task_ephemeral=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_EPHEMERAL_STORAGE:-$(jq -r '.ephemeralStorage.sizeInGiB // ""' "${task_file}")}
 if [ -n "${task_ephemeral}" ]; then
   register_command+=(--ephemeral-storage "sizeInGiB=${task_ephemeral}")
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -143,7 +143,7 @@ service_defined=$(
   aws ecs describe-services \
     "${aws_default_args[@]+"${aws_default_args[@]}"}" \
     "${aws_describe_service_args[@]}" \
-    --query 'services[?status=="ACTIVE"].status' \
+    --query "services[?status=='ACTIVE'].status" \
     --output text \
     | wc -l
 )

--- a/hooks/command
+++ b/hooks/command
@@ -23,32 +23,30 @@ target_group=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP:-""}
 load_balancer_name=${BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME:-""}
 target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
 target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
-task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION:-""}
 
-if [ -z "${task_definition}" ]; then
-  task_file=$(mktemp)
-  if ! aws ecs describe-task-definition --task-definition "${task_family}" --query 'taskDefinition' >"${task_file}"; then
-    echo ":boom: Could not get task definitions (you need to define one in your repository and use the task-definition option)"
-    exit 1
-  fi
-
-  task_definition_json=$(cat "${task_file}")
-  rm "${task_file}"
-else
-  task_definition_json=$(cat "${task_definition}")
+if [ -n "${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION:-""}" ]; then
+  echo ":boom: The task-definition parameter has been deprecated"
+  exit 1
 fi
 
-if [ -z "${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS:-}" ]; then
-  container_definitions_json=$(jq '.containerDefinitions' <"${task_definition_json}")
-else
-  container_definitions_json=$(cat "${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS}")
+task_file=$(mktemp)
+trap 'rm "${task_file}"' EXIT
+
+if ! aws ecs describe-task-definition --task-definition "${task_family}" --query 'taskDefinition' >"${task_file}"; then
+  echo "Could not obtain existing task definition"
 fi
 
-if [[ $(jq '. | keys | first' <<<"$container_definitions_json") != "0" ]]; then
-    echo "^^^"
-    echo "Invalid Container Definitions"
-    echo 'JSON definition should be in the format of [{"image": "..."}]'
-    exit 1
+if [ -n "${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS:-}" ]; then
+  container_definitions="${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS}"
+else
+  container_definitions=$(mktemp)
+  trap 'rm "${container_definitions}"' EXIT
+  jq '.containerDefinitions' "${task_file}" >"${container_definitions}"
+fi
+
+if [ "$(jq -r '. | type' "${container_definitions}")" != "array" ]; then
+  echo 'Invalid Container Definitions (should be in the format of [{"image": "..."}] )'
+  exit 1
 fi
 
 # necessary for compatibility with bash 4.3
@@ -67,7 +65,8 @@ fi
 target_group=$(eval "echo $target_group")
 load_balancer_name=$(eval "echo $load_balancer_name")
 
-## This is the template definition of your containers
+# jq has no in-place edition https://github.com/jqlang/jq/issues/105
+container_definitions_json=$(cat "${container_definitions}")
 image_idx=0
 for image in "${images[@]}"; do
   container_definitions_json=$(
@@ -105,10 +104,6 @@ fi
 execution_role=${BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE:-""}
 if [[ -n "${execution_role}" ]]; then
     register_command+=(--execution-role-arn "${execution_role}")
-fi
-
-if [[ -n "${task_definition}" ]]; then
-    register_command+=(--cli-input-json "${task_definition_json}")
 fi
 
 echo "--- :ecs: register command:"

--- a/hooks/command
+++ b/hooks/command
@@ -23,15 +23,23 @@ target_group=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP:-""}
 load_balancer_name=${BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME:-""}
 target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
 target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
+task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION:-""}
 
-if [ -z "${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS:-}" ]; then
-  container_definitions=$(mktemp)
-  if ! aws ecs describe-task-definition --task-definition "${task_family}" --query 'taskDefinition.containerDefinitions' >"${container_definitions}"; then
-    echo ":boom: Could not get container definitions"
+if [ -z "${task_definition}" ]; then
+  task_file=$(mktemp)
+  if ! aws ecs describe-task-definition --task-definition "${task_family}" --query 'taskDefinition' >"${task_file}"; then
+    echo ":boom: Could not get task definitions (you need to define one in your repository and use the task-definition option)"
     exit 1
   fi
-  container_definitions_json=$(cat "${container_definitions}")
-  rm "${container_definitions}"
+
+  task_definition_json=$(cat "${task_file}")
+  rm "${task_file}"
+else
+  task_definition_json=$(cat "${task_definition}")
+fi
+
+if [ -z "${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS:-}" ]; then
+  container_definitions_json=$(jq '.containerDefinitions' <"${task_definition_json}")
 else
   container_definitions_json=$(cat "${BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS}")
 fi
@@ -99,9 +107,7 @@ if [[ -n "${execution_role}" ]]; then
     register_command+=(--execution-role-arn "${execution_role}")
 fi
 
-task_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION:-""}
 if [[ -n "${task_definition}" ]]; then
-    task_definition_json=$(cat "${task_definition}")
     register_command+=(--cli-input-json "${task_definition_json}")
 fi
 

--- a/hooks/command
+++ b/hooks/command
@@ -45,7 +45,7 @@ else
 fi
 
 if [ "$(jq -r '. | type' "${container_definitions}")" != "array" ]; then
-  echo 'Invalid Container Definitions (should be in the format of [{"image": "..."}] )'
+  echo 'Invalid container definition (should be in the format of [{"image": "..."}] )'
   exit 1
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -32,7 +32,19 @@ configuration:
       type: integer
     target-group:
       type: string
+    task-cpu:
+      type: integer
+    task-ephemeral-storage:
+      type: integer
+    task-ipc-mode:
+      type: string
     task-family:
+      type: string
+    task-memory:
+      type: integer
+    task-network-mode:
+      type: string
+    task-pid-mode:
       type: string
     task-role-arn:
       type: string

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,8 +12,6 @@ configuration:
       type: string
     service:
       type: string
-    task-definition:
-      type: string
     task-family:
       type: string
     service-definition:

--- a/plugin.yml
+++ b/plugin.yml
@@ -41,6 +41,5 @@ configuration:
   required:
     - cluster
     - service
-    - container-definitions
     - task-family
     - image

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,32 +10,32 @@ configuration:
       type: string
     container-definitions:
       type: string
-    service:
+    deployment-config:
       type: string
-    task-family:
+    desired-count:
       type: string
-    service-definition:
+    env:
+      type: array
+    execution-role:
       type: string
     image:
       type: [ string, array ]
-    desired-count:
-      type: string
-    task-role-arn:
-      type: string
-    target-group:
-      type: string
     load-balanccer-name:
+      type: string
+    service:
+      type: string
+    service-definition:
       type: string
     target-container-name:
       type: string
     target-container-port:
       type: integer
-    execution-role:
+    target-group:
       type: string
-    deployment-config:
+    task-family:
       type: string
-    env:
-      type: array
+    task-role-arn:
+      type: string
   required:
     - cluster
     - service

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -20,6 +20,7 @@ setup() {
 @test "Run a deploy when service exists" {
 
   stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'${expected_container_definition}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
@@ -63,6 +64,7 @@ setup() {
   expected_multiple_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  },\n  {\n    "essential": true,\n    "image": "hello-world:alpacas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
 
   stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_multiple_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
@@ -90,6 +92,7 @@ setup() {
   # first command stubbed saves the container definition to ${TMP_DIR}/container_definition for later review and manipulation
   # we should be stubbing a lot more calls, but we don't care about those so let the stubbing fail
   stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo \"\$6\" > ${_TMP_DIR}/container_definition ; echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
@@ -116,6 +119,7 @@ setup() {
 
 @test "Run a deploy when service does not exist" {
   stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --cli-input-json '{}' : echo -n ''" \
@@ -136,6 +140,7 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE_DEFINITION=examples/service-definition.json
 
   stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --cli-input-json $'$expected_service_definition' : echo -n ''" \
@@ -156,6 +161,7 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN=arn:aws:iam::012345678910:role/world
 
   stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
@@ -179,6 +185,7 @@ setup() {
   alb_config='[{"loadBalancers":[{"containerName":"nginx","containerPort":80,"targetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc"}]}]'
 
   stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers targetGroupArn=arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc,containerName=nginx,containerPort=80 --cli-input-json '{}' : echo -n ''" \
@@ -201,6 +208,7 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
 
   stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers loadBalancerName=nginx-elb,containerName=nginx,containerPort=80 --cli-input-json '{}' : echo -n ''" \
@@ -221,6 +229,7 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE=arn:aws:iam::012345678910:role/world
 
   stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' --execution-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
@@ -240,6 +249,7 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION="0/100"
 
   stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=100,minimumHealthyPercent=0 --cli-input-json '{}' : echo -n ''" \
@@ -259,7 +269,12 @@ setup() {
 @test "Run a deploy when the container definition is incorrect" {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=tests/incorrect-container-definition.json
 
+  stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'"
+
   run "$PWD/hooks/command"
   assert_failure
   assert_output --partial 'JSON definition should be in the format of [{"image": "..."}]'
+
+  unstub aws
 }

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -283,8 +283,8 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition \* --query \* : cat examples/hello-world.json" \
     "ecs register-task-definition --family hello-world --container-definitions $'${expected_container_definition}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[?status==\"ACTIVE\"].status' --output text : echo '1'" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[?status==\"ACTIVE\"]' : echo 'null'" \
+    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -9,66 +9,6 @@ expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hel
 expected_task_definition='{\n    "networkMode": "awsvpc"\n}'
 expected_service_definition='{\n    "schedulingStrategy": "DAEMON",\n    "propagateTags": "TASK_DEFINITION"\n}'
 
-@test "Fail with missing cluster" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
-
-  run "$PWD/hooks/command"
-
-  assert_failure
-  assert_output --partial "Missing cluster"
-}
-
-@test "Fail with missing service" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
-
-  run "$PWD/hooks/command"
-
-  assert_failure
-  assert_output --partial "Missing service name"
-}
-
-@test "Fail with missing task family" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
-
-  run "$PWD/hooks/command"
-
-  assert_failure
-  assert_output --partial "Missing task family"
-}
-
-@test "Fail with missing deploy image" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
-
-  run "$PWD/hooks/command"
-
-  assert_failure
-  assert_output --partial "Missing image to use"
-}
-
-@test "Fail with missing container definition" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-
-  run "$PWD/hooks/command"
-
-  assert_failure
-  assert_output --partial "Missing container definition"
-}
-
 @test "Run a deploy when service exists" {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -263,7 +263,7 @@ setup() {
 
   run "$PWD/hooks/command"
   assert_failure
-  assert_output --partial 'Invalid Container Definitions (should be in the format of [{"image": "..."}] )'
+  assert_output --partial 'Invalid container definition (should be in the format of [{"image": "..."}] )'
 
   unstub aws
 }

--- a/tests/existing-data.bats
+++ b/tests/existing-data.bats
@@ -5,22 +5,18 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 # Uncomment to enable stub debug output:
 # export AWS_STUB_DEBUG=/dev/tty
 
-expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
-expected_task_definition='{\n    "networkMode": "awsvpc"\n}'
-expected_service_definition='{\n    "schedulingStrategy": "DAEMON",\n    "propagateTags": "TASK_DEFINITION"\n}'
-
 setup() {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
   export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
 }
 
 @test "Run a deploy when service exists" {
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions $'${expected_container_definition}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/hello-world.json" \
+    "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
@@ -39,7 +35,8 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/task-definition.json
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' --cli-input-json $'$expected_task_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/hello-world.json" \
+    "ecs register-task-definition --family hello-world --container-definitions \* --cli-input-json \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
@@ -55,15 +52,15 @@ setup() {
 }
 
 @test "Run a deploy with multiple images" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/multiple-images.json
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE # we are providing an array
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_0=hello-world:llamas
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_1=hello-world:alpacas
 
   expected_multiple_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  },\n  {\n    "essential": true,\n    "image": "hello-world:alpacas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_multiple_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/multiple-images.json" \
+    "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
@@ -79,17 +76,16 @@ setup() {
 }
 
 @test "Add env vars on multiple images" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/multiple-images.json
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE # we are providing an array
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_0=hello-world:llamas
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_1=hello-world:alpacas
   export BUILDKITE_PLUGIN_ECS_DEPLOY_ENV_0="FOO=bar"
   export BUILDKITE_PLUGIN_ECS_DEPLOY_ENV_1="BAZ=bing"
 
-
   # first command stubbed saves the container definition to ${TMP_DIR}/container_definition for later review and manipulation
   # we should be stubbing a lot more calls, but we don't care about those so let the stubbing fail
   stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/multiple-images.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo \"\$6\" > ${_TMP_DIR}/container_definition ; echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
@@ -116,7 +112,8 @@ setup() {
 
 @test "Run a deploy when service does not exist" {
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/hello-world.json" \
+    "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
@@ -136,9 +133,10 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE_DEFINITION=examples/service-definition.json
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/hello-world.json" \
+    "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
-    "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --cli-input-json $'$expected_service_definition' : echo -n ''" \
+    "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --cli-input-json \* : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
@@ -156,7 +154,8 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN=arn:aws:iam::012345678910:role/world
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/hello-world.json" \
+    "ecs register-task-definition --family hello-world --container-definitions \* --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
@@ -179,7 +178,8 @@ setup() {
   alb_config='[{"loadBalancers":[{"containerName":"nginx","containerPort":80,"targetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc"}]}]'
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/hello-world.json" \
+    "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers targetGroupArn=arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc,containerName=nginx,containerPort=80 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo '$alb_config'" \
@@ -201,7 +201,8 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/hello-world.json" \
+    "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers loadBalancerName=nginx-elb,containerName=nginx,containerPort=80 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo '[{\"loadBalancers\":[{\"loadBalancerName\": \"nginx-elb\",\"containerName\": \"nginx\",\"containerPort\": 80}]}]'" \
@@ -221,7 +222,8 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_EXECUTION_ROLE=arn:aws:iam::012345678910:role/world
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' --execution-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/hello-world.json" \
+    "ecs register-task-definition --family hello-world --container-definitions \* --execution-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
@@ -240,7 +242,8 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION="0/100"
 
   stub aws \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/hello-world.json" \
+    "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=100,minimumHealthyPercent=0 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
@@ -257,9 +260,27 @@ setup() {
 }
 
 @test "Run a deploy when the container definition is incorrect" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=tests/incorrect-container-definition.json
+  
+  stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat tests/incorrect-container-definition.json"
 
   run "$PWD/hooks/command"
+  
   assert_failure
   assert_output --partial 'JSON definition should be in the format of [{"image": "..."}]'
+  
+  unstub aws
+}
+
+@test "Fail with missing container definition and aws failure" {
+  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
+
+  stub aws 'exit 1' # whatever we receive, fail
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "Could not get container definitions"
+
+  unstub aws
 }

--- a/tests/existing-data.bats
+++ b/tests/existing-data.bats
@@ -56,8 +56,6 @@ setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_0=hello-world:llamas
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE_1=hello-world:alpacas
 
-  expected_multiple_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  },\n  {\n    "essential": true,\n    "image": "hello-world:alpacas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
-
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition.containerDefinitions : cat examples/multiple-images.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \

--- a/tests/existing-data.bats
+++ b/tests/existing-data.bats
@@ -273,8 +273,6 @@ setup() {
 }
 
 @test "Fail with missing container definition and aws failure" {
-  unset BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS
-
   stub aws 'exit 1' # whatever we receive, fail
 
   run "$PWD/hooks/command"

--- a/tests/required-options.bats
+++ b/tests/required-options.bats
@@ -51,15 +51,3 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   assert_failure
   assert_output --partial "Missing image to use"
 }
-
-@test "Fail with missing container definition" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
-
-  run "$PWD/hooks/command"
-
-  assert_failure
-  assert_output --partial "Missing container definition"
-}

--- a/tests/required-options.bats
+++ b/tests/required-options.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+load "${BATS_PLUGIN_PATH}/load.bash"
+
+# Uncomment to enable stub debug output:
+# export AWS_STUB_DEBUG=/dev/tty
+
+@test "Fail with missing cluster" {
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "Missing cluster"
+}
+
+@test "Fail with missing service" {
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "Missing service name"
+}
+
+@test "Fail with missing task family" {
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "Missing task family"
+}
+
+@test "Fail with missing deploy image" {
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "Missing image to use"
+}
+
+@test "Fail with missing container definition" {
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "Missing container definition"
+}


### PR DESCRIPTION
* Made the `container_definition` parameter optional (closes #43)
* Refactored the readme (into mandatory and optional parameters)
* refactored the code a bit to make it more streamlined
* cleaned-up the tests a bit
* bumped version in example to next release