### PR TITLE
SUP-1669: Correct Typo with Configuration Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Example: `"arn:aws:iam::012345678910:role/execution-role"`
 
 Requires the `iam:PassRole` permission for the execution role.
 
+#### `load-balancer-name` (optional)
+
+The name of the Elastic Load Balancer (Application or Network) used with the ECS Service.
+
+Example: `application-load-balancer`
+
 #### `region` (optional)
 
 The region we deploy the ECS Service to.

--- a/plugin.yml
+++ b/plugin.yml
@@ -20,7 +20,7 @@ configuration:
       type: string
     image:
       type: [ string, array ]
-    load-balanccer-name:
+    load-balancer-name:
       type: string
     service:
       type: string


### PR DESCRIPTION
`load-balancer-name` had a typo in it's name therefore the Plugin wouldn't create the Environment Variable specified in the hooks scripts.
Additionally, updated the README with information on the Configuration Property