### PR TITLE
Fix missing --region option for lb_config

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -24,6 +24,12 @@ load_balancer_name=${BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME:-""}
 target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
 target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
 
+# default args for all aws cli calls
+aws_default_args=()
+if [ -n "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-}" ]; then
+  aws_default_args+=(--region "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION}")
+fi
+
 if [ -n "${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION:-""}" ]; then
   echo ":boom: The task-definition parameter has been deprecated"
   exit 1
@@ -32,7 +38,14 @@ fi
 task_file=$(mktemp)
 trap 'rm "${task_file}"' EXIT
 
-if ! aws ecs describe-task-definition --task-definition "${task_family}" --query 'taskDefinition' >"${task_file}"; then
+existing_task_definition=$(
+  aws ecs describe-task-definition \
+    "${aws_default_args[@]+"${aws_default_args[@]}"}" \
+    --task-definition "${task_family}" \
+    --query 'taskDefinition' \
+)
+
+if ! existing_task_definition >"${task_file}"; then
   echo "Could not obtain existing task definition"
 fi
 
@@ -54,11 +67,6 @@ if plugin_read_list_into_result "ENV"; then
   env_vars=("${result[@]}")
 else
   env_vars=()
-fi
-
-aws_default_args=()
-if [ -n "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-}" ]; then
-  aws_default_args+=(--region "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION}")
 fi
 
 # Resolve any runtime environment variables it has

--- a/hooks/command
+++ b/hooks/command
@@ -225,7 +225,14 @@ if [[ $service_defined -eq 0 ]]; then
     --cli-input-json "$service_definition_json"
 fi
 
-lb_config=$(aws ecs describe-services --cluster "$cluster" --services "$service_name" --query "services[?status=='ACTIVE']" | jq -r '.[0].loadBalancers[0]')
+lb_config=$(
+  aws ecs describe-services \
+  "${aws_default_args[@]+"${aws_default_args[@]}"}" \
+  "${aws_describe_service_args[@]}" \
+  --query "services[?status=='ACTIVE']" \
+  | jq -r '.[0].loadBalancers[0]'
+)
+
 error="+++ ^^^
 +++ Cannot update a service to add/remove a load balancer. First delete the service and then run again, or rename the service to force a new one to be created"
 

--- a/hooks/command
+++ b/hooks/command
@@ -276,8 +276,7 @@ aws ecs wait services-stable \
 
 service_events=$(aws ecs describe-services \
   ${aws_default_args[@]+"${aws_default_args[@]}"} \
-  --cluster "${cluster}" \
-  --service "${service_name}" \
+  "${aws_describe_service_args[@]}" \
   --query 'services[].events' --output text)
 
 if [[ $deploy_exitcode -eq 0 ]]; then

--- a/hooks/command
+++ b/hooks/command
@@ -169,7 +169,7 @@ echo "Registered ${task_family}:${task_revision}"
 # Create service if it doesn't already exist
 aws_describe_service_args=(
   --cluster "$cluster"
-  --service "$service_name"
+  --services "$service_name"
 )
 
 aws_create_service_args=(

--- a/hooks/command
+++ b/hooks/command
@@ -42,7 +42,7 @@ existing_task_definition=$(
   aws ecs describe-task-definition \
     "${aws_default_args[@]+"${aws_default_args[@]}"}" \
     --task-definition "${task_family}" \
-    --query 'taskDefinition' \
+    --query 'taskDefinition'
 )
 
 if ! existing_task_definition >"${task_file}"; then

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -21,11 +21,11 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'${expected_container_definition}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -55,11 +55,11 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_multiple_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -83,11 +83,11 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo \"\$6\" > ${_TMP_DIR}/container_definition ; echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -110,12 +110,12 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -131,12 +131,12 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --cli-input-json $'$expected_service_definition' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -152,11 +152,11 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -176,12 +176,12 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers targetGroupArn=arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc,containerName=nginx,containerPort=80 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo '$alb_config'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -199,12 +199,12 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers loadBalancerName=nginx-elb,containerName=nginx,containerPort=80 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo '[{\"loadBalancers\":[{\"loadBalancerName\": \"nginx-elb\",\"containerName\": \"nginx\",\"containerPort\": 80}]}]'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -220,11 +220,11 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' --execution-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -240,12 +240,12 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=100,minimumHealthyPercent=0 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 

--- a/tests/existing-data.bats
+++ b/tests/existing-data.bats
@@ -17,11 +17,11 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition : cat examples/described-task.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -39,11 +39,11 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition : cat examples/described-task-multiple.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -65,11 +65,11 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition : cat examples/described-task-multiple.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo \"\$6\" > ${_TMP_DIR}/container_definition ; echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -92,12 +92,12 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition : cat examples/described-task.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -113,12 +113,12 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition : cat examples/described-task.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --cli-input-json \* : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -134,11 +134,11 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition : cat examples/described-task.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -158,12 +158,12 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition : cat examples/described-task.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers targetGroupArn=arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc,containerName=nginx,containerPort=80 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo '$alb_config'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -181,12 +181,12 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition : cat examples/described-task.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers loadBalancerName=nginx-elb,containerName=nginx,containerPort=80 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo '[{\"loadBalancers\":[{\"loadBalancerName\": \"nginx-elb\",\"containerName\": \"nginx\",\"containerPort\": 80}]}]'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -202,11 +202,11 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition : cat examples/described-task.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* --execution-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -222,12 +222,12 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition : cat examples/described-task.json" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
+    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
     "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=100,minimumHealthyPercent=0 --cli-input-json '{}' : echo -n ''" \
     "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
 
   run "$PWD/hooks/command"
 


### PR DESCRIPTION
When running buildkite agent in a different AWS Region to ECS cluster and using `region` param in config, the command fails with this message:
```
An error occurred (ClusterNotFoundException) when calling the DescribeServices operation: Cluster not found.
🚨 Error: The command exited with status 255
user command error: The plugin ecs-deploy command hook exited with status 255
```

I noticed that when calling awc cli for obtaining `lb_config` data `--region` option is missing.