### PR TITLE
Deprecate ECS service creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ steps:
     concurrency_group: "my-service-deploy"
     concurrency: 1
     plugins:
-      - ecs-deploy#v2.1.0:
+      - ecs-deploy#v3.0.0:
           cluster: "my-ecs-cluster"
           service: "my-service"
           container-definitions: "examples/hello-world.json"

--- a/README.md
+++ b/README.md
@@ -96,17 +96,11 @@ Example: `"my-task"`
 
 ### Optional
 
-#### `deployment-configuration` (optional)
+#### `env` (array)
 
-The minimum and maximum percentage of tasks that should be maintained during a deployment. Defaults to `100/200`
+An array of environment variables to add to *every* image's task definition in the `NAME=VALUE` format
 
-Example: `"0/100"`
-
-#### `env` (optional)
-
-An array of environment variables to add to *every* image's task definition
-
-#### `execution-role` (optional)
+#### `execution-role`
 
 The Execution Role ARN used by ECS to pull container images and secrets.
 
@@ -114,69 +108,38 @@ Example: `"arn:aws:iam::012345678910:role/execution-role"`
 
 Requires the `iam:PassRole` permission for the execution role.
 
-#### `load-balancer-name` (optional)
-
-The name of the Elastic Load Balancer (Application or Network) used with the ECS Service.
-
-Example: `application-load-balancer`
-
-#### `region` (optional)
+#### `region`
 
 The region we deploy the ECS Service to.
 
-#### `service-definition`
-
-The file path to the ECS service definition JSON file. Parameters specified in this file will be overridden by other arguments if set, e.g. `cluster`, `desired-count`, etc. Note that currently this json input will only be used when creating the service, NOT when updating it.
-
-Example: `"ecs/service.json"`
-```json
-{
-  "schedulingStrategy": "DAEMON",
-  "propagateTags": "TASK_DEFINITION"
-}
-```
-
-#### `target-container-name` (optional)
-
-The Container Name to forward ALB requests to.
-
-#### `target-container-port` (optional)
-
-The Container Port to forward requests to.
-
-#### `target-group` (optional)
-
-The Target Group ARN to map the service to.
-
-Example: `"arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc"`
-
-#### `task-cpu` (optional, integer)
+#### `task-cpu` (integer)
 
 CPU Units to assign to the task (1024 constitutes a whole CPU). Example: `256` (1/4 of a CPU).
 
-#### `task-ephemeral-storage` (optional, integer)
+#### `task-ephemeral-storage` (integer)
 
 Amount of GBs to assign in ephemeral storage to the task. Example: `25`.
 
-#### `task-ipc-mode` (optional)
+#### `task-ipc-mode`
 
 IPC resource namespace to use in the task. If specified, should be one of `host`, `task` or `none`.
 
-#### `task-memory` (optional, integer)
+#### `task-memory` (integer)
 
 Amount of memory (in Mbs) to allocate for the task. Example: `1024` (1Gb).
 
-#### `task-network-mode` (optional)
+#### `task-network-mode`
 
 Docker networking mode for the containers running in the task. If specified, should be one of `bridge`, `host`, `awsvpc` or `none`.
 
-#### `task-pid-mode` (optional)
+#### `task-pid-mode`
 
 Process namespace to use for containers in the task. If specified, should be one of `host` or `task`.
 
-#### `task-role-arn` (optional)
+#### `task-role-arn`
 
 An IAM ECS Task Role to assign to tasks.
+
 Requires the `iam:PassRole` permission for the ARN specified.
 
 ## AWS Roles
@@ -194,8 +157,6 @@ Policy:
     Effect: Allow
     Resource: '*'
 ```
-
-This plugin will create the ECS Service if it does not already exist, which additionally requires the `ecs:CreateService` permission.
 
 ## Developing
 

--- a/examples/service-definition.json
+++ b/examples/service-definition.json
@@ -1,4 +1,0 @@
-{
-    "schedulingStrategy": "DAEMON",
-    "propagateTags": "TASK_DEFINITION"
-}

--- a/hooks/command
+++ b/hooks/command
@@ -17,17 +17,25 @@ if ! plugin_read_list_into_result "IMAGE"; then
 fi
 images=("${result[@]}")
 
-# optional configurations
-desired_count=${BUILDKITE_PLUGIN_ECS_DEPLOY_DESIRED_COUNT:-"1"}
-target_group=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP:-""}
-load_balancer_name=${BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME:-""}
-target_container=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME:-""}
-target_port=${BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT:-""}
-
 if [ -n "${BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION:-""}" ]; then
   echo ":boom: The task-definition parameter has been deprecated"
   exit 1
 fi
+
+if [ -n "${BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE_DEFINITION:-""}" ]; then
+  echo ":boom: The service-definition parameter has been deprecated"
+  echo "Create the service outside of this plugin first (using CloudFormation or Terraform)"
+  exit 1
+fi
+
+for DEPRECATED_CONFIG in deployment-config deployment-configuration desired-count load-balancer-name target-container-name target-container-port target-group; do
+  VAR_NAME="BUILDKITE_PLUGIN_ECS_DEPLOY_$(echo "${DEPRECATED_CONFIG}" | tr 'a-z-' 'A-Z_')"
+
+  if [ -n "${!VAR_NAME:-""}" ]; then
+    echo ":warning: The ${DEPRECATED_CONFIG} parameter has been deprecated"
+    echo "Please configure the service outside of this plugin"
+  fi
+done
 
 task_file=$(mktemp)
 trap 'rm "${task_file}"' EXIT
@@ -165,91 +173,6 @@ fi
 
 task_revision=$(jq '.taskDefinition.revision' <<< "$json_output")
 echo "Registered ${task_family}:${task_revision}"
-
-# Create service if it doesn't already exist
-aws_describe_service_args=(
-  --cluster "$cluster"
-  --service "$service_name"
-)
-
-aws_create_service_args=(
-  --cluster "$cluster"
-  --service-name "$service_name"
-  --task-definition "${task_family}:${task_revision}"
-  --desired-count "$desired_count"
-)
-
-service_definition=${BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE_DEFINITION:-""}
-if [[ -n "${service_definition}" ]]; then
-  service_definition_json=$(cat "${service_definition}")
-else
-  service_definition_json="{}"
-fi
-
-service_defined=$(
-  aws ecs describe-services \
-    "${aws_default_args[@]+"${aws_default_args[@]}"}" \
-    "${aws_describe_service_args[@]}" \
-    --query "services[?status=='ACTIVE'].status" \
-    --output text \
-    | wc -l
-)
-
-deployment_config=${BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION:-"100/200"}
-IFS="/" read -r -a min_max_percent <<< "${deployment_config}"
-min_deploy_perc=${min_max_percent[0]}
-max_deploy_perc=${min_max_percent[1]}
-
-aws_create_service_args+=(--deployment-configuration "maximumPercent=${max_deploy_perc},minimumHealthyPercent=${min_deploy_perc}")
-
-if [[ -n $target_container ]] && [[ -n $target_port ]]; then
-  if [[ -n $target_group ]]; then
-    load_balancer_ref="targetGroupArn=${target_group}"
-  elif [[ -n $load_balancer_name ]]; then
-    load_balancer_ref="loadBalancerName=${load_balancer_name}"
-  else
-    echo "+++ ^^^"
-    echo '+++ You must specify either target-group or load-balancer-name'
-    exit 1
-  fi
-
-  aws_create_service_args+=(--load-balancers "${load_balancer_ref},containerName=${target_container},containerPort=${target_port}")
-fi
-
-if [[ $service_defined -eq 0 ]]; then
-  echo "--- :ecs: Creating a Service $service_name in cluster $cluster"
-
-  aws ecs create-service \
-    "${aws_default_args[@]+"${aws_default_args[@]}"}" \
-    "${aws_create_service_args[@]}" \
-    --cli-input-json "$service_definition_json"
-fi
-
-lb_config=$(aws ecs describe-services --cluster "$cluster" --services "$service_name" --query "services[?status=='ACTIVE']" | jq -r '.[0].loadBalancers[0]')
-error="+++ ^^^
-+++ Cannot update a service to add/remove a load balancer. First delete the service and then run again, or rename the service to force a new one to be created"
-
-# No easy way to tell if the target group has changed, since describe-services only returns the load balancer name
-if [[ "$lb_config" == "null" ]]; then
-  if [[ -n "$target_group" ]] || [[ -n "$load_balancer_name" ]]; then
-    echo "$error. ELB configured but none set in container"
-    exit 1
-  fi
-fi
-
-if [[ "$lb_config" == "null" ]]; then
-  # noop
-  true
-elif [[ $(echo "$lb_config" | jq -r '.containerName') != "$target_container" ]] || [[ $(echo "$lb_config" | jq -r '.containerPort') -ne $target_port ]]; then
-  echo "$error. Container config differs"
-  exit 1
-elif [[ -n "$target_group" ]] && [[ $(echo "$lb_config" | jq -r '.targetGroupArn') != "$target_group" ]]; then
-  echo "$error. ALB config differs"
-  exit 1
-elif [[ -n "$load_balancer_name" ]] && [[ $(echo "$lb_config" | jq -r '.loadBalancerName') != "$load_balancer_name" ]]; then
-  echo "$error. ELB config differs"
-  exit 1
-fi
 
 echo "--- :ecs: Updating service for ${service_name}"
 aws ecs update-service \

--- a/hooks/command
+++ b/hooks/command
@@ -69,10 +69,6 @@ if [ -n "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-}" ]; then
   aws_default_args+=(--region "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION}")
 fi
 
-# Resolve any runtime environment variables it has
-target_group=$(eval "echo $target_group")
-load_balancer_name=$(eval "echo $load_balancer_name")
-
 # jq has no in-place edition https://github.com/jqlang/jq/issues/105
 container_definitions_json=$(cat "${container_definitions}")
 image_idx=0

--- a/hooks/command
+++ b/hooks/command
@@ -37,10 +37,15 @@ for DEPRECATED_CONFIG in deployment-config deployment-configuration desired-coun
   fi
 done
 
+aws_default_args=()
+if [ -n "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-}" ]; then
+  aws_default_args+=(--region "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION}")
+fi
+
 task_file=$(mktemp)
 trap 'rm "${task_file}"' EXIT
 
-if ! aws ecs describe-task-definition --task-definition "${task_family}" --query 'taskDefinition' >"${task_file}"; then
+if ! aws ecs describe-task-definition "${aws_default_args[@]+"${aws_default_args[@]}"}" --task-definition "${task_family}" --query 'taskDefinition' >"${task_file}"; then
   echo "Could not obtain existing task definition"
 fi
 
@@ -62,11 +67,6 @@ if plugin_read_list_into_result "ENV"; then
   env_vars=("${result[@]}")
 else
   env_vars=()
-fi
-
-aws_default_args=()
-if [ -n "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION:-}" ]; then
-  aws_default_args+=(--region "${BUILDKITE_PLUGIN_ECS_DEPLOY_REGION}")
 fi
 
 # jq has no in-place edition https://github.com/jqlang/jq/issues/105

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,27 +10,13 @@ configuration:
       type: string
     container-definitions:
       type: string
-    deployment-config:
-      type: string
-    desired-count:
-      type: string
     env:
       type: array
     execution-role:
       type: string
     image:
       type: [ string, array ]
-    load-balancer-name:
-      type: string
     service:
-      type: string
-    service-definition:
-      type: string
-    target-container-name:
-      type: string
-    target-container-port:
-      type: integer
-    target-group:
       type: string
     task-cpu:
       type: integer

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,8 @@ configuration:
       type: string
     image:
       type: [ string, array ]
+    region:
+      type: string
     service:
       type: string
     task-cpu:
@@ -24,14 +26,17 @@ configuration:
       type: integer
     task-ipc-mode:
       type: string
+      enum: [ "host", "none", "task"]
     task-family:
       type: string
     task-memory:
       type: integer
     task-network-mode:
       type: string
+      enum: [ "awsvpc", "bridge", "host", "none" ]
     task-pid-mode:
       type: string
+      enum: [ "host", "task" ]
     task-role-arn:
       type: string
   required:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -30,15 +30,6 @@ setup() {
   unstub aws
 }
 
-@test "Run a deploy with a task definition json file" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/task-definition.json
-
-  run "$PWD/hooks/command"
-
-  assert_failure
-  assert_output --partial "The task-definition parameter has been deprecated"
-}
-
 @test "Run a deploy with multiple images" {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/multiple-images.json
   unset BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE # we are providing an array

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -5,9 +5,6 @@ load "${BATS_PLUGIN_PATH}/load.bash"
 # Uncomment to enable stub debug output:
 # export AWS_STUB_DEBUG=/dev/tty
 
-expected_container_definition='[\n  {\n    "essential": true,\n    "image": "hello-world:llamas",\n    "memory": 100,\n    "name": "sample",\n    "portMappings": [\n      {\n        "containerPort": 80,\n        "hostPort": 80\n      }\n    ]\n  }\n]'
-expected_service_definition='{\n    "schedulingStrategy": "DAEMON",\n    "propagateTags": "TASK_DEFINITION"\n}'
-
 setup() {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
   export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
@@ -20,9 +17,7 @@ setup() {
 
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
-    "ecs register-task-definition --family hello-world --container-definitions $'${expected_container_definition}' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
-    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
+    "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
@@ -55,8 +50,6 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_multiple_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
-    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
@@ -83,8 +76,6 @@ setup() {
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
     "ecs register-task-definition --family hello-world --container-definitions \* : echo \"\$6\" > ${_TMP_DIR}/container_definition ; echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
-    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
@@ -106,102 +97,12 @@ setup() {
   unstub aws
 }
 
-@test "Run a deploy when service does not exist" {
-  stub aws \
-    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
-    "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --cli-input-json '{}' : echo -n ''" \
-    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-}
-
-@test "Run a deploy with a new service with definition" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE_DEFINITION=examples/service-definition.json
-
-  stub aws \
-    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
-    "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --cli-input-json $'$expected_service_definition' : echo -n ''" \
-    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-}
-
 @test "Run a deploy with task role" {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_ROLE_ARN=arn:aws:iam::012345678910:role/world
 
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
-    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-}
-
-@test "Run a deploy with target group" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP=arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME=nginx
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
-
-  alb_config='[{"loadBalancers":[{"containerName":"nginx","containerPort":80,"targetGroupArn":"arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc"}]}]'
-
-  stub aws \
-    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
-    "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers targetGroupArn=arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/alb/e987e1234cd12abc,containerName=nginx,containerPort=80 --cli-input-json '{}' : echo -n ''" \
-    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo '$alb_config'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-}
-
-@test "Run a deploy with ELBv1" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME=nginx-elb
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME=nginx
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=80
-
-  stub aws \
-    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
-    "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 --load-balancers loadBalancerName=nginx-elb,containerName=nginx,containerPort=80 --cli-input-json '{}' : echo -n ''" \
-    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo '[{\"loadBalancers\":[{\"loadBalancerName\": \"nginx-elb\",\"containerName\": \"nginx\",\"containerPort\": 80}]}]'" \
+    "ecs register-task-definition --family hello-world --container-definitions \* --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
@@ -219,9 +120,7 @@ setup() {
 
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' --execution-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo '1'" \
-    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
+    "ecs register-task-definition --family hello-world --container-definitions \* --execution-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
     "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
@@ -230,40 +129,6 @@ setup() {
 
   assert_success
   assert_output --partial "Service is up 🚀"
-
-  unstub aws
-}
-
-@test "Create a service with deployment configuration" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION="0/100"
-
-  stub aws \
-    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
-    "ecs register-task-definition --family hello-world --container-definitions $'$expected_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
-    "ecs describe-services --cluster my-cluster --service my-service --query \"services[?status=='ACTIVE'].status\" --output text : echo -n ''" \
-    "ecs create-service --cluster my-cluster --service-name my-service --task-definition hello-world:1 --desired-count 1 --deployment-configuration maximumPercent=100,minimumHealthyPercent=0 --cli-input-json '{}' : echo -n ''" \
-    "ecs describe-services --cluster my-cluster --services my-service --query \"services[?status=='ACTIVE']\" : echo 'null'" \
-    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
-    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
-
-  run "$PWD/hooks/command"
-
-  assert_success
-  assert_output --partial "Service is up 🚀"
-
-  unstub aws
-}
-
-@test "Run a deploy when the container definition is incorrect" {
-  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=tests/incorrect-container-definition.json
-
-  stub aws \
-    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'"
-
-  run "$PWD/hooks/command"
-  assert_failure
-  assert_output --partial 'Invalid container definition (should be in the format of [{"image": "..."}] )'
 
   unstub aws
 }

--- a/tests/deprecated-options.bats
+++ b/tests/deprecated-options.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load "${BATS_PLUGIN_PATH}/load.bash"
+
+# Uncomment to enable stub debug output:
+# export AWS_STUB_DEBUG=/dev/tty
+
+setup() {
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_IMAGE=hello-world:llamas
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CONTAINER_DEFINITIONS=examples/hello-world.json
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_CLUSTER=my-cluster
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world
+}
+
+@test "Fail with task-definition" {
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_DEFINITION=examples/task-definition.json
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "The task-definition parameter has been deprecated"
+}
+
+@test "Fail with service definition" {
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE_DEFINITION=examples/service-definition.json
+
+  run "$PWD/hooks/command"
+
+  assert_failure
+  assert_output --partial "service-definition parameter has been deprecated"
+}
+
+@test "Warn with other options" {
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIG='100/200'
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_DEPLOYMENT_CONFIGURATION='100/200'
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_DESIRED_COUNT='2'
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_LOAD_BALANCER_NAME='test-elb'
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_NAME='mycontainer'
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_CONTAINER_PORT=8000
+  export BUILDKITE_PLUGIN_ECS_DEPLOY_TARGET_GROUP='mygroup'
+
+  stub aws \
+    "ecs describe-task-definition --task-definition hello-world --query 'taskDefinition' : echo '{}'" \
+    "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
+    "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
+    "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
+    "ecs describe-services --cluster my-cluster --service my-service --query 'services[].events' --output text : echo ok"
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "deployment-config parameter has been deprecated"
+  assert_output --partial "deployment-configuration parameter has been deprecated"
+  assert_output --partial "load-balancer-name parameter has been deprecated"
+  assert_output --partial "target-container-name parameter has been deprecated"
+  assert_output --partial "target-container-port parameter has been deprecated"
+  assert_output --partial "target-group parameter has been deprecated"
+
+  unstub aws
+}

--- a/tests/incorrect-container-definition.json
+++ b/tests/incorrect-container-definition.json
@@ -1,9 +1,0 @@
-{
-  "containerDefinitions": [
-    {
-      "name": "nginx",
-      "image": "nginx",
-      "essential": true
-    }
-  ]
-}

--- a/tests/required-options.bats
+++ b/tests/required-options.bats
@@ -2,9 +2,6 @@
 
 load "${BATS_PLUGIN_PATH}/load.bash"
 
-# Uncomment to enable stub debug output:
-# export AWS_STUB_DEBUG=/dev/tty
-
 @test "Fail with missing cluster" {
   export BUILDKITE_PLUGIN_ECS_DEPLOY_SERVICE=my-service
   export BUILDKITE_PLUGIN_ECS_DEPLOY_TASK_FAMILY=hello-world


### PR DESCRIPTION
Based on the issues found testing #95 and in preparation of the next major release, I am removing all the code related to the creation of an ECS service from the plugin. Supporting that scenario accounts for over 30% of the plugin's code and even then it does a very poor job due to the nature and complexity of ECS services and how they interact with other infrastructure. I believe that their creation and configuration should be done with tools more suitable for it (like CloudFormation, Terraform, Pulumi, etc.).

I have made the plugin fail when the service configuration to create is provided but only print a warning when options related to the updating of the service are included.

While I was at it, I also included the fix for region support (same as #102) and added an appropriate test to prevent it from breaking in the future.