### PR TITLE
Feat: Set Task Definitions to Inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Example: `"my-task"`
 
 ### Optional
 
+### `deregister-tasks` (boolean)
+
+Controls if previous task definitions are set to `INACTIVE` after a successful deploy. Default: `false`
+
+Requires the `ecs:DeregisterTaskDefinition` IAM Action
+
 #### `env` (array)
 
 An array of environment variables to add to *every* image's task definition in the `NAME=VALUE` format

--- a/hooks/command
+++ b/hooks/command
@@ -156,6 +156,9 @@ if [ -n "${task_compat_reqs}" ]; then
   register_command+=(--requires-compatibilities "${task_compat_reqs}")
 fi
 
+# Task Deregistration Control
+task_deregistration=${BUILDKITE_PLUGIN_ECS_DEPLOY_DEREGISTER_TASKS:-false}
+
 echo "--- :ecs: register command:"
 
 json_output=$("${register_command[@]}")
@@ -185,7 +188,6 @@ aws ecs wait services-stable \
   --cluster "${cluster}" \
   --services "${service_name}" || deploy_exitcode=$?
 
-
 service_events=$(aws ecs describe-services \
   ${aws_default_args[@]+"${aws_default_args[@]}"} \
   --cluster "${cluster}" \
@@ -195,6 +197,10 @@ service_events=$(aws ecs describe-services \
 if [[ $deploy_exitcode -eq 0 ]]; then
   echo "--- :ecs: Service is up 🚀"
   echo "$service_events"
+
+  if [[ "${task_deregistration}" == "true" ]]; then
+    deregister_old_task_definitions "${task_family}" "${task_revision}"
+  fi
 else
   echo "+++ :ecs: Service failed to deploy ❌"
   echo "$service_events"

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,6 +10,8 @@ configuration:
       type: string
     container-definitions:
       type: string
+    deregister-tasks:
+      type: boolean
     env:
       type: array
     execution-role:


### PR DESCRIPTION
Adds a new conditional feature to set previous task definitions to `INACTIVE`, currently old definitions are left `ACTIVE`. The feature is optionally controlled via the `deregister-tasks` flag and is `false` by default.

Adds:
- Conditional to control Task Deregistration
- `deregister_old_task_definitions` function in `plugin.bash`

Updates:
- Success logic to remove old tasks if enables
- README
- Tests