### PR TITLE
Only report events since deploy

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -173,6 +173,7 @@ fi
 task_revision=$(jq '.taskDefinition.revision' <<< "$json_output")
 echo "Registered ${task_family}:${task_revision}"
 
+update_time=$(date -u +%Y-%m-%dT%H:%M:%S)
 echo "--- :ecs: Updating service for ${service_name}"
 aws ecs update-service \
   ${aws_default_args[@]+"${aws_default_args[@]}"} \
@@ -188,12 +189,14 @@ aws ecs wait services-stable \
   --cluster "${cluster}" \
   --services "${service_name}" || deploy_exitcode=$?
 
-
+## Get events since the time when we began the update, in ascending order
 service_events=$(aws ecs describe-services \
   ${aws_default_args[@]+"${aws_default_args[@]}"} \
   --cluster "${cluster}" \
   --services "${service_name}" \
-  --query 'services[].events' --output text)
+  --query "services[].events[]" |
+  jq "[.[] | select(.createdAt > \"${update_time}\")] | sort_by(.createdAt)" |
+  jq -r '.[] | "\(.createdAt)\t\(.id)\t\(.message)"')
 
 if [[ $deploy_exitcode -eq 0 ]]; then
   echo "--- :ecs: Service is up 🚀"

--- a/hooks/command
+++ b/hooks/command
@@ -173,7 +173,8 @@ fi
 task_revision=$(jq '.taskDefinition.revision' <<< "$json_output")
 echo "Registered ${task_family}:${task_revision}"
 
-update_time=$(date -u +%Y-%m-%dT%H:%M:%S)
+# Take advantage of the fact that ISO8601 format is sortable
+update_time=$(date +'%Y-%m-%dT%H:%M:%S')
 echo "--- :ecs: Updating service for ${service_name}"
 aws ecs update-service \
   ${aws_default_args[@]+"${aws_default_args[@]}"} \

--- a/hooks/command
+++ b/hooks/command
@@ -195,9 +195,7 @@ service_events=$(aws ecs describe-services \
   ${aws_default_args[@]+"${aws_default_args[@]}"} \
   --cluster "${cluster}" \
   --services "${service_name}" \
-  --query "services[].events[]" |
-  jq "[.[] | select(.createdAt > \"${update_time}\")] | sort_by(.createdAt)" |
-  jq -r '.[] | "\(.createdAt)\t\(.id)\t\(.message)"')
+  --query "services[].events[?createdAt >= '${update_time}']" --output text | sort)
 
 if [[ $deploy_exitcode -eq 0 ]]; then
   echo "--- :ecs: Service is up 🚀"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -20,7 +20,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
 
   run "$PWD/hooks/command"
 
@@ -43,7 +43,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions $'$expected_multiple_container_definition' : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
 
   run "$PWD/hooks/command"
 
@@ -96,7 +96,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
 
   run "$PWD/hooks/command"
 
@@ -114,7 +114,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* --execution-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[{\"id\": \"9\", \"createdAt\": \"2025-04-17T12:34:56.789000+00:00\", \"message\": \"ok\" }]'"
 
   run "$PWD/hooks/command"
 
@@ -133,7 +133,7 @@ setup() {
     "ecs register-task-definition --region custom-region --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --region custom-region --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --region custom-region --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --region custom-region --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --region custom-region --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
 
   run "$PWD/hooks/command"
 

--- a/tests/deprecated-options.bats
+++ b/tests/deprecated-options.bats
@@ -59,3 +59,4 @@ setup() {
 
   unstub aws
 }
+

--- a/tests/deprecated-options.bats
+++ b/tests/deprecated-options.bats
@@ -45,7 +45,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
 
   run "$PWD/hooks/command"
 

--- a/tests/deprecated-options.bats
+++ b/tests/deprecated-options.bats
@@ -45,7 +45,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
+    "ecs describe-services --cluster my-cluster --services my-service --query \* --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -59,4 +59,3 @@ setup() {
 
   unstub aws
 }
-

--- a/tests/existing-data.bats
+++ b/tests/existing-data.bats
@@ -19,7 +19,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
+    "ecs describe-services --cluster my-cluster --services my-service --query \* --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -39,7 +39,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
+    "ecs describe-services --cluster my-cluster --services my-service --query \* --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -63,7 +63,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* : echo \"\$6\" > ${_TMP_DIR}/container_definition ; echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
+    "ecs describe-services --cluster my-cluster --services my-service --query \* --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -90,7 +90,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
+    "ecs describe-services --cluster my-cluster --services my-service --query \* --output text : echo ok"
 
   run "$PWD/hooks/command"
 
@@ -108,7 +108,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* --execution-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
+    "ecs describe-services --cluster my-cluster --services my-service --query \* --output text : echo ok"
 
   run "$PWD/hooks/command"
 

--- a/tests/existing-data.bats
+++ b/tests/existing-data.bats
@@ -19,7 +19,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
 
   run "$PWD/hooks/command"
 
@@ -39,7 +39,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
 
   run "$PWD/hooks/command"
 
@@ -90,7 +90,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* --task-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
 
   run "$PWD/hooks/command"
 
@@ -108,7 +108,7 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* --execution-role-arn arn:aws:iam::012345678910:role/world : echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
 
   run "$PWD/hooks/command"
 

--- a/tests/existing-data.bats
+++ b/tests/existing-data.bats
@@ -63,20 +63,20 @@ setup() {
     "ecs register-task-definition --family hello-world --container-definitions \* : echo \"\$6\" > ${_TMP_DIR}/container_definition ; echo '{\"taskDefinition\":{\"revision\":1}}'" \
     "ecs update-service --cluster my-cluster --service my-service --task-definition hello-world:1 : echo ok" \
     "ecs wait services-stable --cluster my-cluster --services my-service : echo ok" \
-    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events' --output text : echo ok"
+    "ecs describe-services --cluster my-cluster --services my-service --query 'services[].events[]' : echo '[]'"
 
   run "$PWD/hooks/command"
 
   assert_success
 
   # check that the definition was updated accordingly
-  assert_equal "$(jq -r '.[0].environment[0].name'  "${_TMP_DIR}"/container_definition)" 'FOO'
+  assert_equal "$(jq -r '.[0].environment[0].name' "${_TMP_DIR}"/container_definition)" 'FOO'
   assert_equal "$(jq -r '.[0].environment[0].value' "${_TMP_DIR}"/container_definition)" 'bar'
-  assert_equal "$(jq -r '.[1].environment[0].name'  "${_TMP_DIR}"/container_definition)" 'FOO'
+  assert_equal "$(jq -r '.[1].environment[0].name' "${_TMP_DIR}"/container_definition)" 'FOO'
   assert_equal "$(jq -r '.[1].environment[0].value' "${_TMP_DIR}"/container_definition)" 'bar'
-  assert_equal "$(jq -r '.[0].environment[1].name'  "${_TMP_DIR}"/container_definition)" 'BAZ'
+  assert_equal "$(jq -r '.[0].environment[1].name' "${_TMP_DIR}"/container_definition)" 'BAZ'
   assert_equal "$(jq -r '.[0].environment[1].value' "${_TMP_DIR}"/container_definition)" 'bing'
-  assert_equal "$(jq -r '.[1].environment[1].name'  "${_TMP_DIR}"/container_definition)" 'BAZ'
+  assert_equal "$(jq -r '.[1].environment[1].name' "${_TMP_DIR}"/container_definition)" 'BAZ'
   assert_equal "$(jq -r '.[1].environment[1].value' "${_TMP_DIR}"/container_definition)" 'bing'
 
   unstub aws
@@ -119,15 +119,15 @@ setup() {
 }
 
 @test "Run a deploy when the container definition is incorrect" {
-  
+
   stub aws \
     "ecs describe-task-definition --task-definition hello-world --query taskDefinition : echo '{}'"
 
   run "$PWD/hooks/command"
-  
+
   assert_failure
   assert_output --partial 'Invalid container definition (should be in the format of [{"image": "..."}] )'
-  
+
   unstub aws
 }
 


### PR DESCRIPTION
Once a deployment has stabilised, this plugin currently reports the first page of events of `aws ecs describe-services` for the service, limited by the default page size of 100.

However, the retrieved events:
1. are displayed in reverse chronological order
2. are likely to contain events that happened _before_ the service update (deployment) began.

This PR filters to only include events that occurred _after_ the service update request, and sorts them by timestamp. ~It uses `jq` which is already a dependency~.
