### PR TITLE
Doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Policy:
   - Action:
     - ecr:DescribeImages
     - ecs:DescribeServices
+    - ecs:DescribeTaskDefinition
     - ecs:RegisterTaskDefinition
     - ecs:UpdateService
     Effect: Allow


### PR DESCRIPTION
When skipping the `container-definitions` option, I found this permission was also required